### PR TITLE
docs: reference new `Accidental` class instead of enum

### DIFF
--- a/lib/src/classes/enharmonic_note.dart
+++ b/lib/src/classes/enharmonic_note.dart
@@ -44,11 +44,11 @@ class EnharmonicNote extends Enharmonic<Note> {
   ///
   /// Examples:
   /// ```dart
-  /// EnharmonicNote.note(4, Accidentals.sharp)
-  ///   == const Note(Notes.re, Accidentals.sharp)
+  /// EnharmonicNote.note(4, Accidental.sharp)
+  ///   == const Note(Notes.re, Accidental.sharp)
   ///
-  /// EnharmonicNote.note(5, Accidentals.flat)
-  ///   == const Note(Notes.fa, Accidentals.flat)
+  /// EnharmonicNote.note(5, Accidental.flat)
+  ///   == const Note(Notes.fa, Accidental.flat)
   /// ```
   static Note note(int semitones, [Accidental? preferredAccidental]) {
     final enharmonicNotes = EnharmonicNote.fromSemitones(semitones).items;
@@ -68,8 +68,8 @@ class EnharmonicNote extends Enharmonic<Note> {
   /// Examples:
   /// ```dart
   /// EnharmonicNote({
-  ///   const Note(Notes.re, Accidentals.flat),
-  ///   const Note(Notes.ut, Accidentals.sharp),
+  ///   const Note(Notes.re, Accidental.flat),
+  ///   const Note(Notes.ut, Accidental.sharp),
   /// }).semitones == 2
   ///
   /// EnharmonicNote.fromSemitones(4).semitones == 4
@@ -84,8 +84,8 @@ class EnharmonicNote extends Enharmonic<Note> {
   /// ```dart
   /// EnharmonicNote({const Note(Notes.ut)}).transposeBy(6)
   ///   == EnharmonicNote({
-  ///     const Note(Notes.fa, Accidentals.sharp),
-  ///     const Note(Notes.sol, Accidentals.flat),
+  ///     const Note(Notes.fa, Accidental.sharp),
+  ///     const Note(Notes.sol, Accidental.flat),
   ///   })
   /// ```
   @override

--- a/lib/src/classes/key_signature.dart
+++ b/lib/src/classes/key_signature.dart
@@ -27,9 +27,9 @@ class KeySignature {
   ///
   /// Example:
   /// ```dart
-  /// const KeySignature(2, Accidentals.flat).tonalities
+  /// const KeySignature(2, Accidental.flat).tonalities
   ///   == RelativeTonalities({
-  ///     const Tonality(Note(Notes.si, Accidentals.flat), Modes.major),
+  ///     const Tonality(Note(Notes.si, Accidental.flat), Modes.major),
   ///     const Tonality(Note(Notes.sol), Modes.minor),
   ///   })
   /// ```

--- a/lib/src/classes/note.dart
+++ b/lib/src/classes/note.dart
@@ -18,7 +18,7 @@ class Note implements MusicItem, Comparable<Note> {
   ///
   /// Examples:
   /// ```dart
-  /// Note.fromTonalityAccidentals(2, Modes.major, Accidentals.sharp)
+  /// Note.fromTonalityAccidentals(2, Modes.major, Accidental.sharp)
   ///   == const Note(Notes.re)
   ///
   /// Note.fromTonalityAccidentals(0, Modes.minor)
@@ -45,7 +45,7 @@ class Note implements MusicItem, Comparable<Note> {
   ///
   /// Examples:
   /// ```dart
-  /// Note.fromRawAccidentals(2, Accidentals.sharp)
+  /// Note.fromRawAccidentals(2, Accidental.sharp)
   ///   == const Note(Notes.re)
   ///
   /// Note.fromRawAccidentals(0)
@@ -72,7 +72,7 @@ class Note implements MusicItem, Comparable<Note> {
   /// Examples:
   /// ```dart
   /// const Note(Notes.re).semitones == 3
-  /// const Note(Notes.fa, Accidentals.sharp).semitones == 7
+  /// const Note(Notes.fa, Accidental.sharp).semitones == 7
   /// ```
   @override
   int get semitones => chromaticModExcludeZero(note.value + accidentalValue);
@@ -141,7 +141,7 @@ class Note implements MusicItem, Comparable<Note> {
   ///   == const Interval(Intervals.second, Qualities.minor)
   ///
   /// const Note(Notes.re)
-  ///         .exactInterval(const Note(Notes.la, Accidentals.flat)) ==
+  ///         .exactInterval(const Note(Notes.la, Accidental.flat)) ==
   ///     const Interval(Intervals.fifth, Qualities.diminished)
   /// ```
   Interval exactInterval(Note note) {
@@ -158,7 +158,7 @@ class Note implements MusicItem, Comparable<Note> {
   ///
   /// Examples:
   /// ```dart
-  /// const Note(Notes.mi, Accidentals.flat).transposeBy(-3)
+  /// const Note(Notes.mi, Accidental.flat).transposeBy(-3)
   ///   == const Note(Notes.ut)
   ///
   /// const Note(Notes.la).transposeBy(5)
@@ -170,7 +170,7 @@ class Note implements MusicItem, Comparable<Note> {
   ///
   /// const Note(Notes.sol).transposeBy(
   ///   const Interval(Intervals.third, Qualities.major, descending: true),
-  /// ) == const Note(Notes.mi, Accidentals.flat)
+  /// ) == const Note(Notes.mi, Accidental.flat)
   /// ```
   /// ```
   Note transposeBy(int semitones, [Accidental? preferredAccidental]) =>

--- a/lib/src/classes/relative_tonalities.dart
+++ b/lib/src/classes/relative_tonalities.dart
@@ -43,9 +43,9 @@ class RelativeTonalities implements Comparable<RelativeTonalities> {
   /// Example:
   /// ```dart
   /// RelativeTonalities({
-  ///   const Tonality(Note(Notes.mi, Accidentals.flat), Modes.major),
+  ///   const Tonality(Note(Notes.mi, Accidental.flat), Modes.major),
   ///   const Tonality(Note(Notes.ut), Modes.minor),
-  /// }).accidental == Accidentals.flat
+  /// }).accidental == Accidental.flat
   /// ```
   Accidental get accidental => _itemsAccidental(tonalities);
 

--- a/lib/src/classes/tonality.dart
+++ b/lib/src/classes/tonality.dart
@@ -55,7 +55,7 @@ class Tonality implements Comparable<Tonality> {
   /// const Tonality(Note(Notes.re), Modes.minor).relative
   ///   == const Tonality(Note(Notes.fa), Modes.major)
   ///
-  /// const Tonality(Note(Notes.si, Accidentals.flat), Modes.major).relative
+  /// const Tonality(Note(Notes.si, Accidental.flat), Modes.major).relative
   ///   == const Tonality(Note(Notes.sol), Modes.minor)
   /// ```
   Tonality get relative => Tonality(
@@ -74,7 +74,7 @@ class Tonality implements Comparable<Tonality> {
   /// Example:
   /// ```dart
   /// const Tonality(Note(Notes.la), Modes.major).keySignature
-  ///   == const KeySignature(3, Accidentals.sharp)
+  ///   == const KeySignature(3, Accidental.sharp)
   /// ```
   KeySignature get keySignature => KeySignature.fromDistance(
         exactFifthsDistance(

--- a/lib/src/utils/music.dart
+++ b/lib/src/utils/music.dart
@@ -24,7 +24,7 @@ final Set<EnharmonicNote> circleOfFifths = SplayTreeSet<EnharmonicNote>.from({
 /// Examples:
 /// ```dart
 /// shortestFifthsDistance(
-///   EnharmonicNote({const Note(Notes.fa, Accidentals.sharp)}),
+///   EnharmonicNote({const Note(Notes.fa, Accidental.sharp)}),
 ///   EnharmonicNote({const Note(Notes.la)}),
 /// ) == -3
 ///
@@ -57,13 +57,13 @@ int shortestFifthsDistance(
 /// Examples:
 /// ```dart
 /// exactFifthsDistance(
-///   const Note(Notes.la, Accidentals.flat),
-///   const Note(Notes.ut, Accidentals.sharp),
+///   const Note(Notes.la, Accidental.flat),
+///   const Note(Notes.ut, Accidental.sharp),
 /// ) == 11
 ///
 /// exactFifthsDistance(
-///   const Note(Notes.la, Accidentals.flat),
-///   const Note(Notes.re, Accidentals.flat),
+///   const Note(Notes.la, Accidental.flat),
+///   const Note(Notes.re, Accidental.flat),
 /// ) == -1
 /// ```
 int exactFifthsDistance(Note note1, Note note2) => note1.intervalDistance(


### PR DESCRIPTION
Continues #8