### PR TITLE
chore(pubspec): bump version 0.3.0

### DIFF
--- a/.github/workflows/analysis-ci.yml
+++ b/.github/workflows/analysis-ci.yml
@@ -28,7 +28,7 @@ jobs:
         id: cache
         with:
           path: ~/.pub-cache/hosted
-          key: ${{ runner.os }}-pubspec-${{ env.DART_SDK_VERSION }}-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-pubspec-${{ env.DART_SDK_VERSION }}-${{ hashFiles('**/pubspec.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pubspec-${{ env.DART_SDK_VERSION }}-
             ${{ runner.os }}-pubspec-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: music_notes
 description: Music notes library
-version: 0.1.0
+version: 0.3.0
 
 repository: https://github.com/albertms10/music_notes.git
 
@@ -14,5 +14,5 @@ dependencies:
   test: ^1.24.1
 
 dev_dependencies:
-  dart_code_metrics: ^5.7.0
+  dart_code_metrics: ^5.7.1
   very_good_analysis: ^4.0.0+1


### PR DESCRIPTION
Also, the `pubspec.yaml` file will serve as the cache key for the Analysis CI workflow. As a library package, committing `pubspec.lock` is discouraged and, thus, unavailable at that point. See [Private files](https://dart.dev/guides/libraries/private-files#pubspeclock).

Fixes #7