### PR TITLE
test(note): add test cases for `difference`

### DIFF
--- a/lib/src/note/note.dart
+++ b/lib/src/note/note.dart
@@ -88,6 +88,13 @@ class Note implements MusicItem {
       (note.value + accidental.semitones).chromaticModExcludeZero;
 
   /// Returns the difference in semitones between this [Note] and [other].
+  ///
+  /// Examples:
+  /// ```dart
+  /// Note.c.difference(Note.d) == 2
+  /// Note.eFlat.difference(Note.bFlat) == 7
+  /// Note.eFlat.difference(Note.bFlat) == 7
+  /// ```
   int difference(Note other) => (other.semitones - semitones).chromaticMod;
 
   /// Returns the exact fifths distance between this and [other].

--- a/test/src/main.dart
+++ b/test/src/main.dart
@@ -8,6 +8,7 @@ import 'music_test.dart' as music_test;
 import 'note/accidental_test.dart' as accidental_test;
 import 'note/enharmonic_note_test.dart' as enharmonic_note_test;
 import 'note/note_test.dart' as note_test;
+import 'note/notes_test.dart' as notes_test;
 import 'tonality/key_signature_test.dart' as key_signature_test;
 import 'tonality/modes_test.dart' as modes_test;
 import 'tonality/tonality_test.dart' as tonality_test;
@@ -22,6 +23,7 @@ void main() {
   accidental_test.main();
   enharmonic_note_test.main();
   note_test.main();
+  notes_test.main();
   key_signature_test.main();
   modes_test.main();
   tonality_test.main();

--- a/test/src/note/note_test.dart
+++ b/test/src/note/note_test.dart
@@ -34,11 +34,22 @@ void main() {
         'should return the difference in semitones with another Note',
         () {
           expect(Note.c.difference(Note.c), 0);
-          expect(
-            const Note(Notes.e, Accidental.sharp).difference(Note.f),
-            0,
-          );
+          expect(const Note(Notes.e, Accidental.sharp).difference(Note.f), 0);
+          expect(Note.c.difference(Note.dFlat), 1);
+          expect(Note.c.difference(Note.cSharp), 1);
+          expect(Note.b.difference(Note.c), 1);
+          expect(Note.f.difference(Note.g), 2);
+          expect(Note.f.difference(Note.aFlat), 3);
+          expect(Note.e.difference(Note.aFlat), 4);
+          expect(Note.a.difference(Note.d), 5);
           expect(Note.d.difference(Note.aFlat), 6);
+          expect(Note.eFlat.difference(Note.bFlat), 7);
+          expect(Note.dSharp.difference(Note.aSharp), 7);
+          expect(Note.d.difference(Note.aSharp), 8);
+          expect(Note.cSharp.difference(Note.bFlat), 9);
+          expect(Note.cSharp.difference(Note.b), 10);
+          expect(Note.dFlat.difference(Note.b), 10);
+          expect(Note.c.difference(Note.b), 11);
         },
       );
     });


### PR DESCRIPTION
Adds missing `notes_test.main()` call from #54.