### PR TITLE
fix(scale_pattern): return correct descending `PositionedNote` scale in `from`

### DIFF
--- a/lib/src/scale/scale_pattern.dart
+++ b/lib/src/scale/scale_pattern.dart
@@ -224,10 +224,13 @@ final class ScalePattern {
           [scalable],
           (scale, interval) => [...scale, scale.last.transposeBy(interval)],
         ),
-        _descendingIntervalSteps?.fold(
-          [scalable],
-          (scale, interval) => [...?scale, scale!.last.transposeBy(-interval)],
-        ),
+        _descendingIntervalSteps?.reversed
+            .fold(
+              [scalable],
+              (scale, interval) => [...scale, scale.last.transposeBy(interval)],
+            )
+            .reversed
+            .toList(),
       );
 
   /// Returns the mirrored scale version of this [ScalePattern].

--- a/lib/src/scale/scale_pattern.dart
+++ b/lib/src/scale/scale_pattern.dart
@@ -224,6 +224,9 @@ final class ScalePattern {
           [scalable],
           (scale, interval) => [...scale, scale.last.transposeBy(interval)],
         ),
+        // We iterate over the `reversed` descending step list to make sure both
+        // regular and descending scales match, e.g., their octave in
+        // `PositionedNote` lists.
         _descendingIntervalSteps?.reversed
             .fold(
               [scalable],

--- a/test/src/scale/scale_pattern_test.dart
+++ b/test/src/scale/scale_pattern_test.dart
@@ -164,17 +164,15 @@ void main() {
                 Note.f.sharp.sharp.inOctave(2),
                 Note.g.sharp.inOctave(2),
               ],
-              // TODO(albertms10): Failing test: descending scale should start
-              //  from octave 2. See #140.
               [
+                Note.g.sharp.inOctave(2),
+                Note.f.sharp.inOctave(2),
+                Note.e.inOctave(2),
+                Note.d.sharp.inOctave(2),
+                Note.c.sharp.inOctave(2),
+                Note.b.inOctave(1),
+                Note.a.sharp.inOctave(1),
                 Note.g.sharp.inOctave(1),
-                Note.f.sharp.inOctave(1),
-                Note.e.inOctave(1),
-                Note.d.sharp.inOctave(1),
-                Note.c.sharp.inOctave(1),
-                Note.b.inOctave(0),
-                Note.a.sharp.inOctave(0),
-                Note.g.sharp.inOctave(0),
               ],
             ),
           );

--- a/test/src/scale/scale_test.dart
+++ b/test/src/scale/scale_test.dart
@@ -83,12 +83,10 @@ void main() {
           ScalePattern.melodicMinor.from(Note.c).toString(),
           'C Melodic minor (C D E♭ F G A B C, C B♭ A♭ G F E♭ D C)',
         );
-        // TODO(albertms10): Failing test: descending scale start from octave 5.
-        //  See 140.
         expect(
           ScalePattern.melodicMinor.from(Note.a.inOctave(4)).toString(),
           'A4 Melodic minor '
-          '(A4 B4 C5 D5 E5 F♯5 G♯5 A5, A4 G4 F4 E4 D4 C4 B3 A3)',
+          '(A4 B4 C5 D5 E5 F♯5 G♯5 A5, A5 G5 F5 E5 D5 C5 B4 A4)',
         );
         expect(
           ScalePattern.majorPentatonic.from(Note.d.inOctave(3)).toString(),


### PR DESCRIPTION
Fixes #140