### PR TITLE
fix(interval_size_extension): return correct `semitones` for large intervals

### DIFF
--- a/lib/src/interval/interval_size_extension.dart
+++ b/lib/src/interval/interval_size_extension.dart
@@ -55,8 +55,13 @@ extension IntervalSizeExtension on int {
   int get semitones {
     assert(this != 0, 'Size must be non-zero');
 
-    return (_sizeToSemitones[abs()] ??
-            (chromaticDivisions + _sizeToSemitones[simplified.abs()]!)) *
+    final simplifiedAbs = simplified.abs();
+    final octaveShift = chromaticDivisions * (_sizeAbsShift ~/ 8);
+
+    // We exclude perfect octaves (simplified as 8) from the lookup because we
+    // want to consider them as 0 (as they were modulo 8).
+    return (_sizeToSemitones[simplifiedAbs == 8 ? 1 : simplifiedAbs]! +
+            octaveShift) *
         sign;
   }
 

--- a/test/src/interval/interval_size_extension_test.dart
+++ b/test/src/interval/interval_size_extension_test.dart
@@ -27,6 +27,7 @@ void main() {
           expect(IntervalSizeExtension.fromSemitones(22), 14);
           expect(IntervalSizeExtension.fromSemitones(24), 15);
           expect(IntervalSizeExtension.fromSemitones(36), 22);
+          expect(IntervalSizeExtension.fromSemitones(48), 29);
         },
       );
 
@@ -73,14 +74,15 @@ void main() {
         expect(15.semitones, 24);
 
         // TODO(albertms10): Failing tests. See #132.
-        // expect(16.semitones, 25);
-        // expect(17.semitones, 27);
-        // expect(18.semitones, 29);
-        // expect(19.semitones, 30);
-        // expect(20.semitones, 32);
-        // expect(21.semitones, 34);
-        // expect(22.semitones, 36);
-        // expect(29.semitones, 48);
+        expect(16.semitones, 25);
+        expect(17.semitones, 27);
+        expect(18.semitones, 29);
+        expect(19.semitones, 31);
+        expect(20.semitones, 32);
+        expect(21.semitones, 34);
+        expect(22.semitones, 36);
+
+        expect(29.semitones, 48);
       });
     });
 

--- a/test/src/note/positioned_note_test.dart
+++ b/test/src/note/positioned_note_test.dart
@@ -230,11 +230,16 @@ void main() {
             Note.c.inOctave(3).interval(Note.c.inOctave(5)),
             const Interval.perfect(15, PerfectQuality.perfect),
           );
-          // TODO(albertms10): Failing test. See #132.
-          // expect(
-          //   Note.c.inOctave(3).interval(Note.c.inOctave(6)),
-          //   const Interval.perfect(22, PerfectQuality.perfect),
-          // );
+
+          expect(
+            Note.c.inOctave(3).interval(Note.c.inOctave(6)),
+            const Interval.perfect(22, PerfectQuality.perfect),
+          );
+
+          expect(
+            Note.c.inOctave(2).interval(Note.c.inOctave(6)),
+            const Interval.perfect(29, PerfectQuality.perfect),
+          );
 
           // TODO(albertms10): add test case for:
           //  `Note.c.inOctave(4).interval(Note.b.sharp.inOctave(4))`.


### PR DESCRIPTION
Fixes #132