### PR TITLE
:fire: refactor(enharmonic_note)!: remove `shortestFifthsDistance` methods

### DIFF
--- a/lib/music_notes.dart
+++ b/lib/music_notes.dart
@@ -1,7 +1,7 @@
 library music_notes;
 
 import 'dart:collection' show SplayTreeSet;
-import 'dart:math' as math show min, pow;
+import 'dart:math' as math show pow;
 
 import 'package:collection/collection.dart'
     show IterableExtension, ListEquality;

--- a/lib/src/note/enharmonic_note.dart
+++ b/lib/src/note/enharmonic_note.dart
@@ -144,53 +144,6 @@ final class EnharmonicNote extends Enharmonic<Note>
     );
   }
 
-  /// Returns the shortest fifths distance between this and [other].
-  ///
-  /// Example:
-  /// ```dart
-  /// EnharmonicNote.fSharp.shortestFifthsDistance(EnharmonicNote.a) == -3
-  /// EnharmonicNote.dSharp.shortestFifthsDistance(EnharmonicNote.g) == 4
-  /// ```
-  int shortestFifthsDistance(EnharmonicNote other) {
-    final distanceAbove = enharmonicIntervalDistance(other, Interval.P5);
-    final distanceBelow = enharmonicIntervalDistance(other, -Interval.P5);
-    final minDistance = math.min(distanceAbove, distanceBelow);
-
-    return minDistance * (minDistance == distanceAbove ? 1 : -1);
-  }
-
-  /// Returns the shortest iteration distance from [enharmonicNote]
-  /// to [interval].
-  ///
-  /// Example:
-  /// ```dart
-  /// EnharmonicNote.e.enharmonicIntervalDistance(
-  ///     EnharmonicNote.d,
-  ///     Interval.P5,
-  ///   ) == 10
-  ///
-  /// EnharmonicNote.e.enharmonicIntervalDistance(
-  ///     EnharmonicNote.d,
-  ///     -Interval.P5,
-  ///   ) == 2
-  /// ```
-  int enharmonicIntervalDistance(
-    EnharmonicNote enharmonicNote,
-    Interval interval,
-  ) {
-    var distance = 0;
-    var currentPitch = semitones;
-    var tempEnharmonicNote = EnharmonicNote(currentPitch);
-
-    while (tempEnharmonicNote != enharmonicNote) {
-      distance++;
-      currentPitch += interval.semitones;
-      tempEnharmonicNote = EnharmonicNote(currentPitch.chromaticModExcludeZero);
-    }
-
-    return distance;
-  }
-
   /// Performs a pitch-class multiplication modulo 12 of this [EnharmonicNote].
   ///
   /// Example:

--- a/test/src/note/enharmonic_note_test.dart
+++ b/test/src/note/enharmonic_note_test.dart
@@ -309,21 +309,6 @@ void main() {
       });
     });
 
-    group('.shortestFifthsDistance()', () {
-      test('should return the shortest fifths distance from other', () {
-        expect(EnharmonicNote.c.shortestFifthsDistance(EnharmonicNote.c), 0);
-        expect(EnharmonicNote.c.shortestFifthsDistance(EnharmonicNote.e), 4);
-        expect(
-          EnharmonicNote.fSharp.shortestFifthsDistance(EnharmonicNote.a),
-          -3,
-        );
-        expect(
-          EnharmonicNote.dSharp.shortestFifthsDistance(EnharmonicNote.g),
-          4,
-        );
-      });
-    });
-
     group('operator *', () {
       test(
         'should return the pitch-class multiplication modulo 12 of this '


### PR DESCRIPTION
Use `Interval.distanceBetween` instead.