### PR TITLE
:recycle: refactor(positioned_note)!: make `octave` argument required

### DIFF
--- a/lib/src/note/note.dart
+++ b/lib/src/note/note.dart
@@ -205,7 +205,7 @@ final class Note implements Comparable<Note>, Scalable<Note> {
   /// Note.c.inOctave(3) == const PositionedNote(Note.c, 3)
   /// Note.a.flat.inOctave(2) == PositionedNote(Note.a.flat, 2)
   /// ```
-  PositionedNote inOctave(int octave) => PositionedNote(this, octave);
+  PositionedNote inOctave(int octave) => PositionedNote(this, octave: octave);
 
   /// Returns the circle of fifths starting from this [Note] up to [distance].
   ///

--- a/lib/src/note/positioned_note.dart
+++ b/lib/src/note/positioned_note.dart
@@ -11,7 +11,7 @@ final class PositionedNote
   final int octave;
 
   /// Creates a new [PositionedNote] from [Note] arguments and [octave].
-  const PositionedNote(this.note, [this.octave = 4]);
+  const PositionedNote(this.note, {required this.octave});
 
   static const _superPrime = '′';
   static const _subPrime = '͵';
@@ -33,7 +33,7 @@ final class PositionedNote
     if (scientificNotationMatch != null) {
       return PositionedNote(
         Note.parse(scientificNotationMatch[1]!),
-        int.parse(scientificNotationMatch[2]!),
+        octave: int.parse(scientificNotationMatch[2]!),
       );
     }
 
@@ -55,7 +55,7 @@ final class PositionedNote
 
       return PositionedNote(
         Note.parse(notePart),
-        notePart[0].isUpperCase
+        octave: notePart[0].isUpperCase
             ? switch (primes?.first) {
                 ',' || _subPrime => middleOctave - primes!.length - 1,
                 _ => middleOctave - 1,
@@ -250,7 +250,7 @@ final class PositionedNote
   /// ) == const Frequency(430.54)
   /// ```
   Frequency equalTemperamentFrequency({
-    PositionedNote reference = const PositionedNote(Note.a),
+    PositionedNote reference = const PositionedNote(Note.a, octave: 4),
     Frequency frequency = const Frequency(440),
   }) =>
       frequency * EqualTemperament.edo12.ratio(reference.difference(this));

--- a/test/src/note/positioned_note_test.dart
+++ b/test/src/note/positioned_note_test.dart
@@ -919,8 +919,8 @@ void main() {
       test('should return the same hashCode for equal PositionedNotes', () {
         expect(Note.c.inOctave(4).hashCode, Note.c.inOctave(4).hashCode);
         expect(
-          const PositionedNote(Note.a, 3).hashCode,
-          const PositionedNote(Note.a, 3).hashCode,
+          const PositionedNote(Note.a, octave: 3).hashCode,
+          const PositionedNote(Note.a, octave: 3).hashCode,
         );
       });
 
@@ -932,8 +932,8 @@ void main() {
             isNot(equals(Note.c.inOctave(5).hashCode)),
           );
           expect(
-            const PositionedNote(Note.a, 3).hashCode,
-            isNot(equals(const PositionedNote(Note.b, 3).hashCode)),
+            const PositionedNote(Note.a, octave: 3).hashCode,
+            isNot(equals(const PositionedNote(Note.b, octave: 3).hashCode)),
           );
           expect(
             Note.d.inOctave(6).hashCode,


### PR DESCRIPTION
**Breaking change:** `octave` argument in the `PositionedNote` constructor is now named and no longer has a default value.