### PR TITLE
:recycle: refactor(int_extension): simplify modulo methods

### DIFF
--- a/lib/src/interval/interval.dart
+++ b/lib/src/interval/interval.dart
@@ -251,11 +251,13 @@ final class Interval implements Comparable<Interval> {
       (size) =>
           (absoluteSemitones == chromaticDivisions
               ? chromaticDivisions
-              : absoluteSemitones.chromaticMod) ==
+              : absoluteSemitones % chromaticDivisions) ==
           _sizeToSemitones[size],
     );
     if (matchingSize == null) return null;
-    if (absoluteSemitones == 12) return matchingSize * semitones.sign;
+    if (absoluteSemitones == chromaticDivisions) {
+      return matchingSize * semitones.sign;
+    }
 
     final absResult =
         matchingSize + (absoluteSemitones ~/ chromaticDivisions) * 7;
@@ -541,5 +543,5 @@ extension _IntervalSize on int {
   /// (-22)._simplified == -8
   /// ```
   int get _simplified =>
-      _isCompound ? _sizeAbsShift.nModExcludeZero(8) * sign : this;
+      _isCompound ? _sizeAbsShift.nonZeroMod(8) * sign : this;
 }

--- a/lib/src/interval/interval_class.dart
+++ b/lib/src/interval/interval_class.dart
@@ -6,7 +6,7 @@ part of '../../music_notes.dart';
 /// [PitchClass]es.
 ///
 /// The largest [IntervalClass] is [IntervalClass.tritone] (6) since any greater
-/// interval `n` may be reduced to `12 - n`.
+/// interval `n` may be reduced to `chromaticDivisions - n`.
 ///
 /// See [Interval class](https://en.wikipedia.org/wiki/Interval_class).
 @immutable
@@ -15,7 +15,7 @@ final class IntervalClass extends Enharmonic<Interval> {
   const IntervalClass(int semitones)
       : super(
           (semitones % chromaticDivisions) > (chromaticDivisions ~/ 2)
-              ? 12 - (semitones % chromaticDivisions)
+              ? chromaticDivisions - (semitones % chromaticDivisions)
               : semitones % chromaticDivisions,
         );
 

--- a/lib/src/note/base_note.dart
+++ b/lib/src/note/base_note.dart
@@ -38,8 +38,9 @@ enum BaseNote {
   /// BaseNote.fromSemitones(7) == BaseNote.g
   /// BaseNote.fromSemitones(10) == null
   /// ```
-  static BaseNote? fromSemitones(int semitones) => values
-      .firstWhereOrNull((note) => semitones.chromaticMod == note.semitones);
+  static BaseNote? fromSemitones(int semitones) => values.firstWhereOrNull(
+        (note) => semitones % chromaticDivisions == note.semitones,
+      );
 
   /// Returns a [BaseNote] enum item that matches with [ordinal].
   ///
@@ -50,7 +51,7 @@ enum BaseNote {
   /// BaseNote.fromOrdinal(10) == BaseNote.e
   /// ```
   factory BaseNote.fromOrdinal(int ordinal) =>
-      BaseNote.values[ordinal.nModExcludeZero(BaseNote.values.length) - 1];
+      BaseNote.values[ordinal.nonZeroMod(BaseNote.values.length) - 1];
 
   /// Parse [source] as a [BaseNote] and return its value.
   ///

--- a/lib/src/note/note.dart
+++ b/lib/src/note/note.dart
@@ -61,7 +61,8 @@ final class Note implements Comparable<Note>, Scalable<Note> {
   /// Note.d.semitones == 2
   /// Note.f.sharp.semitones == 6
   /// ```
-  int get semitones => (baseNote.semitones + accidental.semitones).chromaticMod;
+  int get semitones =>
+      (baseNote.semitones + accidental.semitones) % chromaticDivisions;
 
   /// Returns the difference in semitones between this [Note] and [other].
   ///
@@ -325,7 +326,7 @@ final class Note implements Comparable<Note>, Scalable<Note> {
 
     return Interval.fromDelta(
       intervalSize,
-      difference(other).chromaticMod - intervalSize._semitones,
+      difference(other) % chromaticDivisions - intervalSize._semitones,
     );
   }
 

--- a/lib/src/note/pitch_class.dart
+++ b/lib/src/note/pitch_class.dart
@@ -182,7 +182,8 @@ final class PitchClass extends Enharmonic<Note>
         final semitones => '$semitones',
       };
 
-  /// Performs a multiplication modulo 12 of this [PitchClass].
+  /// Performs a pitch-class multiplication modulo [chromaticDivisions] of this
+  /// [PitchClass].
   ///
   /// Example:
   /// ```dart

--- a/lib/utils/int_extension.dart
+++ b/lib/utils/int_extension.dart
@@ -1,5 +1,3 @@
-import 'package:music_notes/music_notes.dart';
-
 /// An int extension.
 extension IntExtension on int {
   /// Returns this [int] incremented by [step].
@@ -13,29 +11,17 @@ extension IntExtension on int {
   /// ```
   int incrementBy(int step) => (abs() + step) * (isNegative ? -1 : 1);
 
-  /// Returns the modulo [chromaticDivisions] of this [int].
-  ///
-  /// Example:
-  /// ```dart
-  /// 4.chromaticMod == 4
-  /// 14.chromaticMod == 2
-  /// (-5).chromaticMod == 7
-  /// 0.chromaticMod == 0
-  /// 12.chromaticMod == 0
-  /// ```
-  int get chromaticMod => this % chromaticDivisions;
-
   /// Returns the modulo [n] of this [int]. If this is 0, it returns [n].
   ///
   /// Example:
   /// ```dart
-  /// 9.nModExcludeZero(3) == 3
-  /// 0.nModExcludeZero(5) == 5
-  /// 7.nModExcludeZero(7) == 7
+  /// 9.nonZeroMod(3) == 3
+  /// 7.nonZeroMod(7) == 7
+  /// 0.nonZeroMod(5) == 5
   /// ```
-  int nModExcludeZero(int n) {
-    final modValue = this % n;
+  int nonZeroMod(int n) {
+    final mod = this % n;
 
-    return modValue == 0 ? n : modValue;
+    return mod == 0 ? n : mod;
   }
 }

--- a/test/utils/int_extension_test.dart
+++ b/test/utils/int_extension_test.dart
@@ -20,25 +20,12 @@ void main() {
       });
     });
 
-    group('.chromaticMod', () {
-      test('should return the correct modulo chromatic divisions', () {
-        expect(4.chromaticMod, 4);
-        expect(14.chromaticMod, 2);
-        expect((-5).chromaticMod, 7);
-        expect(0.chromaticMod, 0);
-        expect(12.chromaticMod, 0);
+    group('.nonZeroMod()', () {
+      test('should return the correct non-zero modulo for a given int', () {
+        expect(9.nonZeroMod(3), 3);
+        expect(7.nonZeroMod(7), 7);
+        expect(0.nonZeroMod(5), 5);
       });
-    });
-
-    group('.nModExcludeZero()', () {
-      test(
-        'should return the correct modulo excluding zero for a given int',
-        () {
-          expect(9.nModExcludeZero(3), 3);
-          expect(0.nModExcludeZero(5), 5);
-          expect(7.nModExcludeZero(7), 7);
-        },
-      );
     });
   });
 }


### PR DESCRIPTION
This PR aims to:

- remove `chromaticMod` in favor of its explicit `% chromaticDivisions` usage
- rename `nModExcludeZero` → `nonZeroMod`