### PR TITLE
docs: :book: remove type parameter references in doc comments

### DIFF
--- a/lib/src/harmony/chord.dart
+++ b/lib/src/harmony/chord.dart
@@ -5,22 +5,22 @@ part of '../../music_notes.dart';
 class Chord<T extends Scalable<T>>
     with Chordable<Chord<T>>
     implements Transposable<Chord<T>> {
-  /// The [Scalable<T>] items this [Chord<T>] is built of.
+  /// The [Scalable] items this [Chord] is built of.
   final List<T> items;
 
-  /// Creates a new [Chord<T>] from [items].
+  /// Creates a new [Chord] from [items].
   const Chord(this.items);
 
-  /// The root [Scalable<T>] of this [Chord<T>].
+  /// The root [Scalable] of this [Chord].
   T get root => items.first;
 
-  /// Returns the [ChordPattern] for this [Chord<T>].
+  /// Returns the [ChordPattern] for this [Chord].
   ///
-  /// The pattern is calculated based on the intervals between the notes rather
-  /// than from the root note. This approach helps differentiate compound
-  /// intervals (e.g., [Interval.M9]) from simple intervals (e.g.,
-  /// [Interval.M2]) in chords where distance is not explicit (e.g.,
-  /// [Note] based chords rather than [PositionedNote] based).
+  /// The pattern is calculated based on the intervals between the notes
+  /// rather than from the root note. This approach helps differentiate
+  /// compound intervals (e.g., [Interval.M9]) from simple intervals
+  /// (e.g., [Interval.M2]) in chords where distance is not explicit
+  /// (so, [Note] based chords rather than [PositionedNote] based).
   ///
   /// Example:
   /// ```dart
@@ -39,7 +39,7 @@ class Chord<T extends Scalable<T>>
   /// ```
   List<T> get modifiers => items.skip(3).toList();
 
-  /// Returns a new [Chord<T>] with an [ImperfectQuality.diminished] root triad.
+  /// Returns a new [Chord] with an [ImperfectQuality.diminished] root triad.
   ///
   /// Example:
   /// ```dart
@@ -49,7 +49,7 @@ class Chord<T extends Scalable<T>>
   @override
   Chord<T> get diminished => pattern.diminished.on(root);
 
-  /// Returns a new [Chord<T>] with an [ImperfectQuality.minor] root triad.
+  /// Returns a new [Chord] with an [ImperfectQuality.minor] root triad.
   ///
   /// Example:
   /// ```dart
@@ -59,7 +59,7 @@ class Chord<T extends Scalable<T>>
   @override
   Chord<T> get minor => pattern.minor.on(root);
 
-  /// Returns a new [Chord<T>] with an [ImperfectQuality.major] root triad.
+  /// Returns a new [Chord] with an [ImperfectQuality.major] root triad.
   ///
   /// Example:
   /// ```dart
@@ -69,8 +69,7 @@ class Chord<T extends Scalable<T>>
   @override
   Chord<T> get major => pattern.major.on(root);
 
-  /// Returns a new [Chord<T>] with an [ImperfectQuality.augmented] root
-  /// triad.
+  /// Returns a new [Chord] with an [ImperfectQuality.augmented] root triad.
   ///
   /// Example:
   /// ```dart
@@ -80,12 +79,12 @@ class Chord<T extends Scalable<T>>
   @override
   Chord<T> get augmented => pattern.augmented.on(root);
 
-  /// Returns a new [Chord<T>] adding [interval].
+  /// Returns a new [Chord] adding [interval].
   @override
   Chord<T> add(Interval interval, {Set<int>? replaceSizes}) =>
       pattern.add(interval, replaceSizes: replaceSizes).on(root);
 
-  /// Returns a transposed [Chord<T>] by [interval] from this [Chord<T>].
+  /// Returns a transposed [Chord] by [interval] from this [Chord].
   ///
   /// Example:
   /// ```dart

--- a/lib/src/harmony/chord_pattern.dart
+++ b/lib/src/harmony/chord_pattern.dart
@@ -56,7 +56,7 @@ class ChordPattern with Chordable<ChordPattern> {
         _ => majorTriad,
       };
 
-  /// Returns the [Chord<T>] from [scalable].
+  /// Returns the [Chord] from [scalable].
   ///
   /// Example:
   /// ```dart

--- a/lib/src/scalable.dart
+++ b/lib/src/scalable.dart
@@ -11,21 +11,21 @@ abstract interface class Scalable<T> implements Transposable<T> {
 
 /// A Scalable iterable.
 extension ScalableIterable<T extends Scalable<T>> on Iterable<T> {
-  /// Returns the [Interval]s between [T]s in this [Iterable<T>].
+  /// Returns the [Interval]s between [T]s in this [Iterable].
   Iterable<Interval> get intervalSteps sync* {
     for (var i = 0; i < length - 1; i++) {
       yield elementAt(i).interval(elementAt(i + 1));
     }
   }
 
-  /// Returns the descending [Interval]s between [T]s this [Iterable<T>].
+  /// Returns the descending [Interval]s between [T]s this [Iterable].
   Iterable<Interval> get descendingIntervalSteps sync* {
     for (var i = 0; i < length - 1; i++) {
       yield elementAt(i + 1).interval(elementAt(i));
     }
   }
 
-  /// Returns this [Iterable<T>] transposed by [interval].
+  /// Returns this [Iterable] transposed by [interval].
   Iterable<T> transposeBy(Interval interval) =>
       map((item) => item.transposeBy(interval));
 }

--- a/lib/src/scale/scale.dart
+++ b/lib/src/scale/scale.dart
@@ -5,21 +5,20 @@ part of '../../music_notes.dart';
 /// See [Scale (music)](https://en.wikipedia.org/wiki/Scale_(music)).
 @immutable
 class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
-  /// The [Scalable<T>] degrees that define this [Scale<T>].
+  /// The [Scalable] degrees that define this [Scale].
   final List<T> degrees;
 
-  /// The descending [Scalable<T>] degrees that define this [Scale<T>] (if
-  /// different).
+  /// The descending [Scalable] degrees that define this [Scale] (if different).
   final List<T>? _descendingDegrees;
 
-  /// Creates a new [Scale<T>] instance from [degrees].
+  /// Creates a new [Scale] instance from [degrees].
   const Scale(this.degrees, [this._descendingDegrees]);
 
-  /// The descending [Scalable<T>] degrees that define this [Scale<T>].
+  /// The descending [Scalable] degrees that define this [Scale].
   List<T> get descendingDegrees =>
       _descendingDegrees ?? degrees.reversed.toList();
 
-  /// Returns the [ScalePattern] of this [Scale<T>].
+  /// Returns the [ScalePattern] of this [Scale].
   ///
   /// Example:
   /// ```dart
@@ -31,7 +30,7 @@ class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
         _descendingDegrees?.descendingIntervalSteps.toList(),
       );
 
-  /// Returns the reversed of this [Scale<T>].
+  /// Returns the reversed of this [Scale].
   ///
   /// Example:
   /// ```dart
@@ -42,7 +41,7 @@ class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
   Scale<T> get reversed =>
       Scale(descendingDegrees, _descendingDegrees != null ? degrees : null);
 
-  /// Returns the [Chord<T>] for each [ScaleDegree] of this [Scale<T>].
+  /// Returns the [Chord] for each [ScaleDegree] of this [Scale].
   ///
   /// Example:
   /// ```dart
@@ -59,7 +58,7 @@ class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
   List<Chord<T>> get degreeChords =>
       [for (var i = 1; i < degrees.length; i++) degreeChord(ScaleDegree(i))];
 
-  /// Returns the [T] for the [scaleDegree] of this [Scale<T>].
+  /// Returns the [T] for the [scaleDegree] of this [Scale].
   ///
   /// Example:
   /// ```dart
@@ -79,7 +78,7 @@ class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
     );
   }
 
-  /// Returns the [Chord<T>] for the [scaleDegree] of this [Scale<T>].
+  /// Returns the [Chord] for the [scaleDegree] of this [Scale].
   ///
   /// Example:
   /// ```dart
@@ -89,7 +88,7 @@ class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
   Chord<T> degreeChord(ScaleDegree scaleDegree) =>
       pattern.degreePattern(scaleDegree).on(degree(scaleDegree));
 
-  /// Returns the [Chord<T>] for the [harmonicFunction] of this [Scale<T>].
+  /// Returns the [Chord] for the [harmonicFunction] of this [Scale].
   ///
   /// Example:
   /// ```dart
@@ -113,7 +112,7 @@ class Scale<T extends Scalable<T>> implements Transposable<Scale<T>> {
           )
           .degreeChord(harmonicFunction.scaleDegrees.first);
 
-  /// Returns this [Scale<T>] transposed by [interval].
+  /// Returns this [Scale] transposed by [interval].
   ///
   /// Example:
   /// ```dart


### PR DESCRIPTION
Although `dart doc` builds references as expected, IDE reference navigation does not work.