### PR TITLE
refactor!(note): :recycle: rename `NotationSystem` → `NoteNotation`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
   "cSpell.ignoreWords": ["music"],
   "cSpell.words": [
-    "catalan",
     "chordable",
     "Chordable",
     "Didymean",
@@ -10,8 +9,12 @@
     "helmholtz",
     "heptatonic",
     "ionian",
+    "italian",
     "locrian",
     "lydian",
+    "maggiore",
+    "majeur",
+    "mineur",
     "mixolydian",
     "neapolitan",
     "octatonic",

--- a/lib/src/harmony/chord.dart
+++ b/lib/src/harmony/chord.dart
@@ -5,6 +5,8 @@ part of '../../music_notes.dart';
 /// ---
 /// See also:
 /// * [ChordPattern].
+/// * [Scalable].
+/// * [Chordable].
 @immutable
 class Chord<T extends Scalable<T>>
     with Chordable<Chord<T>>

--- a/lib/src/harmony/chord_pattern.dart
+++ b/lib/src/harmony/chord_pattern.dart
@@ -5,6 +5,7 @@ part of '../../music_notes.dart';
 /// ---
 /// See also:
 /// * [Chord].
+/// * [Interval].
 @immutable
 class ChordPattern with Chordable<ChordPattern> {
   /// The intervals from the root note.

--- a/lib/src/interval/quality.dart
+++ b/lib/src/interval/quality.dart
@@ -6,6 +6,8 @@ part of '../../music_notes.dart';
 /// ---
 /// See also:
 /// * [Interval].
+/// * [PerfectQuality].
+/// * [ImperfectQuality].
 @immutable
 sealed class Quality implements Comparable<Quality> {
   /// Delta semitones from the [Interval].

--- a/lib/src/note/base_note.dart
+++ b/lib/src/note/base_note.dart
@@ -146,10 +146,10 @@ enum BaseNote implements Comparable<BaseNote> {
   }
 
   @override
-  String toString({NotationSystem system = NotationSystem.english}) =>
+  String toString({NoteNotation system = NoteNotation.english}) =>
       switch (system) {
-        NotationSystem.english => name.toUpperCase(),
-        NotationSystem.german => switch (this) {
+        NoteNotation.english => name.toUpperCase(),
+        NoteNotation.german => switch (this) {
             BaseNote.c => 'C',
             BaseNote.d => 'D',
             BaseNote.e => 'E',
@@ -158,7 +158,7 @@ enum BaseNote implements Comparable<BaseNote> {
             BaseNote.a => 'A',
             BaseNote.b => 'H',
           },
-        NotationSystem.catalan => switch (this) {
+        NoteNotation.italian => switch (this) {
             BaseNote.c => 'Do',
             BaseNote.d => 'Re',
             BaseNote.e => 'Mi',
@@ -167,7 +167,7 @@ enum BaseNote implements Comparable<BaseNote> {
             BaseNote.a => 'La',
             BaseNote.b => 'Si',
           },
-        NotationSystem.french => switch (this) {
+        NoteNotation.french => switch (this) {
             BaseNote.c => 'Ut',
             BaseNote.d => 'Ré',
             BaseNote.e => 'Mi',

--- a/lib/src/note/frequency.dart
+++ b/lib/src/note/frequency.dart
@@ -163,13 +163,8 @@ class Frequency implements Comparable<Frequency> {
   int compareTo(Frequency other) => hertz.compareTo(other.hertz);
 }
 
-/// A record containing the closest [Pitch], with delta `cents` and
-/// `hertz`.
-typedef ClosestPitch = (
-  Pitch closestPitch, {
-  Cent cents,
-  double hertz,
-});
+/// A record containing the closest [Pitch], with delta `cents` and `hertz`.
+typedef ClosestPitch = (Pitch closestPitch, {Cent cents, double hertz});
 
 /// A [ClosestPitch] extension.
 extension ClosestPitchExtension on ClosestPitch {

--- a/lib/src/note/note.dart
+++ b/lib/src/note/note.dart
@@ -382,9 +382,9 @@ final class Note implements Comparable<Note>, Scalable<Note> {
   PitchClass toPitchClass() => PitchClass(semitones);
 
   @override
-  String toString({NotationSystem system = NotationSystem.english}) =>
+  String toString({NoteNotation system = NoteNotation.english}) =>
       switch (system) {
-        NotationSystem.german => switch (this) {
+        NoteNotation.german => switch (this) {
             Note(baseNote: BaseNote.b, accidental: Accidental.flat) => 'B',
             // Flattened notes.
             final note when note.accidental.semitones < 0 => switch (
@@ -420,17 +420,17 @@ final class Note implements Comparable<Note>, Scalable<Note> {
       ]);
 }
 
-/// Alphabetic system.
-enum NotationSystem {
-  /// The English alphabetic system.
+/// Note notations.
+enum NoteNotation {
+  /// The English alphabetic notation system.
   english,
 
-  /// The German alphabetic system.
+  /// The German alphabetic notation system.
   german,
 
-  /// The Catalan solmization system.
-  catalan,
+  /// The Italian solmization notation system.
+  italian,
 
-  /// The French solmization system.
+  /// The French solmization notation system.
   french,
 }

--- a/lib/src/tonality/mode.dart
+++ b/lib/src/tonality/mode.dart
@@ -55,18 +55,18 @@ enum TonalMode implements Mode {
       this == TonalMode.major ? TonalMode.minor : TonalMode.major;
 
   @override
-  String toString({NotationSystem system = NotationSystem.english}) =>
+  String toString({NoteNotation system = NoteNotation.english}) =>
       switch (system) {
-        NotationSystem.english => name,
-        NotationSystem.german => switch (this) {
+        NoteNotation.english => name,
+        NoteNotation.german => switch (this) {
             TonalMode.major => 'Dur',
             TonalMode.minor => 'Moll',
           },
-        NotationSystem.catalan => switch (this) {
-            TonalMode.major => 'major',
-            TonalMode.minor => 'menor',
+        NoteNotation.italian => switch (this) {
+            TonalMode.major => 'maggiore',
+            TonalMode.minor => 'minore',
           },
-        NotationSystem.french => switch (this) {
+        NoteNotation.french => switch (this) {
             TonalMode.major => 'majeur',
             TonalMode.minor => 'mineur',
           },

--- a/lib/src/tonality/tonality.dart
+++ b/lib/src/tonality/tonality.dart
@@ -57,12 +57,12 @@ final class Tonality implements Comparable<Tonality> {
   Scale<Note> get scale => mode.scale.on(note);
 
   @override
-  String toString({NotationSystem system = NotationSystem.english}) {
+  String toString({NoteNotation system = NoteNotation.english}) {
     final noteString = note.toString(system: system);
     final modeString = mode.toString(system: system);
 
     return switch (system) {
-      NotationSystem.german => '${switch (mode) {
+      NoteNotation.german => '${switch (mode) {
           TonalMode.minor => noteString.toLowerCase(),
           _ => noteString
         }}-$modeString',

--- a/test/src/note/note_test.dart
+++ b/test/src/note/note_test.dart
@@ -647,122 +647,122 @@ void main() {
 
       test('should return the German string representation of this Note', () {
         expect(
-          Note.c.flat.flat.toString(system: NotationSystem.german),
+          Note.c.flat.flat.toString(system: NoteNotation.german),
           'Ceses',
         );
-        expect(Note.c.flat.toString(system: NotationSystem.german), 'Ces');
-        expect(Note.c.toString(system: NotationSystem.german), 'C');
-        expect(Note.c.sharp.toString(system: NotationSystem.german), 'Cis');
+        expect(Note.c.flat.toString(system: NoteNotation.german), 'Ces');
+        expect(Note.c.toString(system: NoteNotation.german), 'C');
+        expect(Note.c.sharp.toString(system: NoteNotation.german), 'Cis');
         expect(
-          Note.c.sharp.sharp.toString(system: NotationSystem.german),
+          Note.c.sharp.sharp.toString(system: NoteNotation.german),
           'Cisis',
         );
 
         expect(
-          Note.d.flat.flat.toString(system: NotationSystem.german),
+          Note.d.flat.flat.toString(system: NoteNotation.german),
           'Deses',
         );
-        expect(Note.d.flat.toString(system: NotationSystem.german), 'Des');
-        expect(Note.d.toString(system: NotationSystem.german), 'D');
-        expect(Note.d.sharp.toString(system: NotationSystem.german), 'Dis');
+        expect(Note.d.flat.toString(system: NoteNotation.german), 'Des');
+        expect(Note.d.toString(system: NoteNotation.german), 'D');
+        expect(Note.d.sharp.toString(system: NoteNotation.german), 'Dis');
         expect(
-          Note.d.sharp.sharp.toString(system: NotationSystem.german),
+          Note.d.sharp.sharp.toString(system: NoteNotation.german),
           'Disis',
         );
 
         expect(
-          Note.e.flat.flat.toString(system: NotationSystem.german),
+          Note.e.flat.flat.toString(system: NoteNotation.german),
           'Eses',
         );
-        expect(Note.e.flat.toString(system: NotationSystem.german), 'Es');
-        expect(Note.e.toString(system: NotationSystem.german), 'E');
-        expect(Note.e.sharp.toString(system: NotationSystem.german), 'Eis');
+        expect(Note.e.flat.toString(system: NoteNotation.german), 'Es');
+        expect(Note.e.toString(system: NoteNotation.german), 'E');
+        expect(Note.e.sharp.toString(system: NoteNotation.german), 'Eis');
         expect(
-          Note.e.sharp.sharp.toString(system: NotationSystem.german),
+          Note.e.sharp.sharp.toString(system: NoteNotation.german),
           'Eisis',
         );
 
         expect(
-          Note.f.flat.flat.toString(system: NotationSystem.german),
+          Note.f.flat.flat.toString(system: NoteNotation.german),
           'Feses',
         );
-        expect(Note.f.flat.toString(system: NotationSystem.german), 'Fes');
-        expect(Note.f.toString(system: NotationSystem.german), 'F');
-        expect(Note.f.sharp.toString(system: NotationSystem.german), 'Fis');
+        expect(Note.f.flat.toString(system: NoteNotation.german), 'Fes');
+        expect(Note.f.toString(system: NoteNotation.german), 'F');
+        expect(Note.f.sharp.toString(system: NoteNotation.german), 'Fis');
         expect(
-          Note.f.sharp.sharp.toString(system: NotationSystem.german),
+          Note.f.sharp.sharp.toString(system: NoteNotation.german),
           'Fisis',
         );
 
         expect(
-          Note.g.flat.flat.toString(system: NotationSystem.german),
+          Note.g.flat.flat.toString(system: NoteNotation.german),
           'Geses',
         );
-        expect(Note.g.flat.toString(system: NotationSystem.german), 'Ges');
-        expect(Note.g.toString(system: NotationSystem.german), 'G');
-        expect(Note.g.sharp.toString(system: NotationSystem.german), 'Gis');
+        expect(Note.g.flat.toString(system: NoteNotation.german), 'Ges');
+        expect(Note.g.toString(system: NoteNotation.german), 'G');
+        expect(Note.g.sharp.toString(system: NoteNotation.german), 'Gis');
         expect(
-          Note.g.sharp.sharp.toString(system: NotationSystem.german),
+          Note.g.sharp.sharp.toString(system: NoteNotation.german),
           'Gisis',
         );
 
         expect(
-          Note.a.flat.flat.toString(system: NotationSystem.german),
+          Note.a.flat.flat.toString(system: NoteNotation.german),
           'Ases',
         );
-        expect(Note.a.flat.toString(system: NotationSystem.german), 'As');
-        expect(Note.a.toString(system: NotationSystem.german), 'A');
-        expect(Note.a.sharp.toString(system: NotationSystem.german), 'Ais');
+        expect(Note.a.flat.toString(system: NoteNotation.german), 'As');
+        expect(Note.a.toString(system: NoteNotation.german), 'A');
+        expect(Note.a.sharp.toString(system: NoteNotation.german), 'Ais');
         expect(
-          Note.a.sharp.sharp.toString(system: NotationSystem.german),
+          Note.a.sharp.sharp.toString(system: NoteNotation.german),
           'Aisis',
         );
 
         expect(
-          Note.b.flat.flat.toString(system: NotationSystem.german),
+          Note.b.flat.flat.toString(system: NoteNotation.german),
           'Heses',
         );
-        expect(Note.b.flat.toString(system: NotationSystem.german), 'B');
-        expect(Note.b.toString(system: NotationSystem.german), 'H');
-        expect(Note.b.sharp.toString(system: NotationSystem.german), 'His');
+        expect(Note.b.flat.toString(system: NoteNotation.german), 'B');
+        expect(Note.b.toString(system: NoteNotation.german), 'H');
+        expect(Note.b.sharp.toString(system: NoteNotation.german), 'His');
         expect(
-          Note.b.sharp.sharp.toString(system: NotationSystem.german),
+          Note.b.sharp.sharp.toString(system: NoteNotation.german),
           'Hisis',
         );
       });
 
-      test('should return the Catalan string representation of this Note', () {
-        expect(Note.c.toString(system: NotationSystem.catalan), 'Do');
-        expect(Note.c.sharp.toString(system: NotationSystem.catalan), 'Do♯');
-        expect(Note.d.toString(system: NotationSystem.catalan), 'Re');
-        expect(Note.d.flat.toString(system: NotationSystem.catalan), 'Re♭');
-        expect(Note.e.toString(system: NotationSystem.catalan), 'Mi');
-        expect(Note.b.flat.toString(system: NotationSystem.catalan), 'Si♭');
-        expect(Note.f.sharp.toString(system: NotationSystem.catalan), 'Fa♯');
+      test('should return the Italian string representation of this Note', () {
+        expect(Note.c.toString(system: NoteNotation.italian), 'Do');
+        expect(Note.c.sharp.toString(system: NoteNotation.italian), 'Do♯');
+        expect(Note.d.toString(system: NoteNotation.italian), 'Re');
+        expect(Note.d.flat.toString(system: NoteNotation.italian), 'Re♭');
+        expect(Note.e.toString(system: NoteNotation.italian), 'Mi');
+        expect(Note.b.flat.toString(system: NoteNotation.italian), 'Si♭');
+        expect(Note.f.sharp.toString(system: NoteNotation.italian), 'Fa♯');
         expect(
-          Note.a.sharp.sharp.toString(system: NotationSystem.catalan),
+          Note.a.sharp.sharp.toString(system: NoteNotation.italian),
           'La𝄪',
         );
         expect(
-          Note.g.flat.flat.toString(system: NotationSystem.catalan),
+          Note.g.flat.flat.toString(system: NoteNotation.italian),
           'Sol𝄫',
         );
       });
 
       test('should return the French string representation of this Note', () {
-        expect(Note.c.toString(system: NotationSystem.french), 'Ut');
-        expect(Note.c.sharp.toString(system: NotationSystem.french), 'Ut♯');
-        expect(Note.d.toString(system: NotationSystem.french), 'Ré');
-        expect(Note.d.flat.toString(system: NotationSystem.french), 'Ré♭');
-        expect(Note.e.toString(system: NotationSystem.french), 'Mi');
-        expect(Note.b.flat.toString(system: NotationSystem.french), 'Si♭');
-        expect(Note.f.sharp.toString(system: NotationSystem.french), 'Fa♯');
+        expect(Note.c.toString(system: NoteNotation.french), 'Ut');
+        expect(Note.c.sharp.toString(system: NoteNotation.french), 'Ut♯');
+        expect(Note.d.toString(system: NoteNotation.french), 'Ré');
+        expect(Note.d.flat.toString(system: NoteNotation.french), 'Ré♭');
+        expect(Note.e.toString(system: NoteNotation.french), 'Mi');
+        expect(Note.b.flat.toString(system: NoteNotation.french), 'Si♭');
+        expect(Note.f.sharp.toString(system: NoteNotation.french), 'Fa♯');
         expect(
-          Note.a.sharp.sharp.toString(system: NotationSystem.french),
+          Note.a.sharp.sharp.toString(system: NoteNotation.french),
           'La𝄪',
         );
         expect(
-          Note.g.flat.flat.toString(system: NotationSystem.french),
+          Note.g.flat.flat.toString(system: NoteNotation.french),
           'Sol𝄫',
         );
       });

--- a/test/src/tonality/mode_test.dart
+++ b/test/src/tonality/mode_test.dart
@@ -40,26 +40,20 @@ void main() {
         expect(TonalMode.major.toString(), 'major');
         expect(TonalMode.minor.toString(), 'minor');
 
-        expect(TonalMode.major.toString(system: NotationSystem.german), 'Dur');
-        expect(TonalMode.minor.toString(system: NotationSystem.german), 'Moll');
+        expect(TonalMode.major.toString(system: NoteNotation.german), 'Dur');
+        expect(TonalMode.minor.toString(system: NoteNotation.german), 'Moll');
 
         expect(
-          TonalMode.major.toString(system: NotationSystem.catalan),
-          'major',
+          TonalMode.major.toString(system: NoteNotation.italian),
+          'maggiore',
         );
         expect(
-          TonalMode.minor.toString(system: NotationSystem.catalan),
-          'menor',
+          TonalMode.minor.toString(system: NoteNotation.italian),
+          'minore',
         );
 
-        expect(
-          TonalMode.major.toString(system: NotationSystem.french),
-          'majeur',
-        );
-        expect(
-          TonalMode.minor.toString(system: NotationSystem.french),
-          'mineur',
-        );
+        expect(TonalMode.major.toString(system: NoteNotation.french), 'majeur');
+        expect(TonalMode.minor.toString(system: NoteNotation.french), 'mineur');
       });
     });
   });

--- a/test/src/tonality/tonality_test.dart
+++ b/test/src/tonality/tonality_test.dart
@@ -115,56 +115,56 @@ void main() {
       test(
         'should return the German string representation of this Tonality',
         () {
-          expect(Note.c.major.toString(system: NotationSystem.german), 'C-Dur');
+          expect(Note.c.major.toString(system: NoteNotation.german), 'C-Dur');
           expect(
-            Note.d.minor.toString(system: NotationSystem.german),
+            Note.d.minor.toString(system: NoteNotation.german),
             'd-Moll',
           );
           expect(
-            Note.a.flat.major.toString(system: NotationSystem.german),
+            Note.a.flat.major.toString(system: NoteNotation.german),
             'As-Dur',
           );
           expect(
-            Note.f.sharp.minor.toString(system: NotationSystem.german),
+            Note.f.sharp.minor.toString(system: NoteNotation.german),
             'fis-Moll',
           );
           expect(
-            Note.g.sharp.sharp.major.toString(system: NotationSystem.german),
+            Note.g.sharp.sharp.major.toString(system: NoteNotation.german),
             'Gisis-Dur',
           );
           expect(
-            Note.e.flat.flat.minor.toString(system: NotationSystem.german),
+            Note.e.flat.flat.minor.toString(system: NoteNotation.german),
             'eses-Moll',
           );
         },
       );
 
       test(
-        'should return the Catalan string representation of this Tonality',
+        'should return the Italian string representation of this Tonality',
         () {
           expect(
-            Note.c.major.toString(system: NotationSystem.catalan),
-            'Do major',
+            Note.c.major.toString(system: NoteNotation.italian),
+            'Do maggiore',
           );
           expect(
-            Note.d.minor.toString(system: NotationSystem.catalan),
-            'Re menor',
+            Note.d.minor.toString(system: NoteNotation.italian),
+            'Re minore',
           );
           expect(
-            Note.a.flat.major.toString(system: NotationSystem.catalan),
-            'La♭ major',
+            Note.a.flat.major.toString(system: NoteNotation.italian),
+            'La♭ maggiore',
           );
           expect(
-            Note.f.sharp.minor.toString(system: NotationSystem.catalan),
-            'Fa♯ menor',
+            Note.f.sharp.minor.toString(system: NoteNotation.italian),
+            'Fa♯ minore',
           );
           expect(
-            Note.g.sharp.sharp.major.toString(system: NotationSystem.catalan),
-            'Sol𝄪 major',
+            Note.g.sharp.sharp.major.toString(system: NoteNotation.italian),
+            'Sol𝄪 maggiore',
           );
           expect(
-            Note.e.flat.flat.minor.toString(system: NotationSystem.catalan),
-            'Mi𝄫 menor',
+            Note.e.flat.flat.minor.toString(system: NoteNotation.italian),
+            'Mi𝄫 minore',
           );
         },
       );
@@ -173,27 +173,27 @@ void main() {
         'should return the French string representation of this Tonality',
         () {
           expect(
-            Note.c.major.toString(system: NotationSystem.french),
+            Note.c.major.toString(system: NoteNotation.french),
             'Ut majeur',
           );
           expect(
-            Note.d.minor.toString(system: NotationSystem.french),
+            Note.d.minor.toString(system: NoteNotation.french),
             'Ré mineur',
           );
           expect(
-            Note.a.flat.major.toString(system: NotationSystem.french),
+            Note.a.flat.major.toString(system: NoteNotation.french),
             'La♭ majeur',
           );
           expect(
-            Note.f.sharp.minor.toString(system: NotationSystem.french),
+            Note.f.sharp.minor.toString(system: NoteNotation.french),
             'Fa♯ mineur',
           );
           expect(
-            Note.g.sharp.sharp.major.toString(system: NotationSystem.french),
+            Note.g.sharp.sharp.major.toString(system: NoteNotation.french),
             'Sol𝄪 majeur',
           );
           expect(
-            Note.e.flat.flat.minor.toString(system: NotationSystem.french),
+            Note.e.flat.flat.minor.toString(system: NoteNotation.french),
             'Mi𝄫 mineur',
           );
         },


### PR DESCRIPTION
This PR also replaces `NoteNotation.catalan` by its parent `NoteNotation.italian` system.