### PR TITLE
chore(gitignore): 🙈 ignore the `tool` directory instead of `bin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # See https://www.dartlang.org/guides/libraries/private-files
 
-bin/
+tool/
 
 # IntelliJ
 *.iml


### PR DESCRIPTION
Following the Dart language guidelines on [Creating packages](https://dart.dev/guides/libraries/create-packages#providing-additional-files), the `bin` directory should contain any command-line tools intended for public consumption, whilst any tools or executables created during development that aren’t for public use should go under the `tool` directory.