### PR TITLE
fix(deps): 🚚 move `test` to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   meta: ^1.11.0
-  test: ^1.25.2
 
 dev_dependencies:
+  test: ^1.25.2
   very_good_analysis: ^5.1.0


### PR DESCRIPTION
Fixes https://github.com/albertms10/music_notes/issues/440

# Description

Moving `test` to `dev_dependecies` solves the dependency resolution issue. And I think that's the correct place for this dependency anyway.

If this approach is unacceptable, an alternative would be to supply `any` for the package version. i.e.
```
test: any
```

# How can this be tested

1. Install flutter.
2. Clone my fork https://github.com/HussainTaj-W/music_notes.
3. Create a new flutter project.
4. Add the following to your `pubspec.yml`.
   ```yml
   dependencies:
     music_notes:
       path: /path/to/project/music_notes
   ```
5. Run
   ```
   flutter pub get
   ```
6. Expect the dependencies to be resolved successfully.

---

> PS: @albertms10 awesome project btw 👏