### PR TITLE
refactor(enharmonic): ♻️ rename `ClassMixin` → `Enharmonic` mixin

### DIFF
--- a/lib/src/enharmonic.dart
+++ b/lib/src/enharmonic.dart
@@ -1,14 +1,14 @@
 import 'package:collection/collection.dart' show IterableEquality;
 
-/// A Class mixin.
-mixin ClassMixin<Class> {
-  /// The number of semitones that define this [Class].
+/// An enharmonic mixin.
+mixin Enharmonic<C> {
+  /// The number of semitones that define this [C].
   int get semitones;
 
-  /// Creates a new [Class] from [semitones].
-  Class toClass();
+  /// Creates a new [C] from [semitones].
+  C toClass();
 
-  /// Whether [Class] is enharmonically equivalent to [other].
+  /// Whether [C] is enharmonically equivalent to [other].
   ///
   /// See [Enharmonic equivalence](https://en.wikipedia.org/wiki/Enharmonic_equivalence).
   ///
@@ -18,14 +18,13 @@ mixin ClassMixin<Class> {
   /// Note.c.isEnharmonicWith(Note.b.sharp) == true
   /// Note.e.isEnharmonicWith(Note.f) == false
   /// ```
-  bool isEnharmonicWith(ClassMixin<Class> other) =>
-      toClass() == other.toClass();
+  bool isEnharmonicWith(Enharmonic<C> other) => toClass() == other.toClass();
 }
 
-/// A Class iterable.
-extension ClassIterable<Class> on Iterable<ClassMixin<Class>> {
-  /// The [Class] representation of this [Iterable].
-  Iterable<Class> toClass() => map((interval) => interval.toClass());
+/// An enharmonic iterable.
+extension EnharmonicIterable<C> on Iterable<Enharmonic<C>> {
+  /// The [C] representation of this [Iterable].
+  Iterable<C> toClass() => map((interval) => interval.toClass());
 
   /// Whether this [Iterable] is enharmonically equivalent to [other].
   ///
@@ -45,6 +44,6 @@ extension ClassIterable<Class> on Iterable<ClassMixin<Class>> {
   ///
   /// const [Interval.m2].isEnharmonicWith(const [Interval.P4]) == false
   /// ```
-  bool isEnharmonicWith(Iterable<ClassMixin<Class>> other) =>
-      IterableEquality<Class>().equals(toClass(), other.toClass());
+  bool isEnharmonicWith(Iterable<Enharmonic<C>> other) =>
+      IterableEquality<C>().equals(toClass(), other.toClass());
 }

--- a/lib/src/interval/interval.dart
+++ b/lib/src/interval/interval.dart
@@ -3,7 +3,7 @@
 import 'package:meta/meta.dart' show immutable;
 import 'package:music_notes/utils.dart';
 
-import '../class_mixin.dart';
+import '../enharmonic.dart';
 import '../note/note.dart';
 import '../scalable.dart';
 import 'interval_class.dart';
@@ -18,7 +18,7 @@ import 'size.dart';
 /// * [IntervalClass].
 @immutable
 final class Interval
-    with ClassMixin<IntervalClass>
+    with Enharmonic<IntervalClass>
     implements Comparable<Interval> {
   /// Number of lines and spaces (or alphabet letters) spanning the two notes,
   /// including the beginning and end.
@@ -327,9 +327,9 @@ final class Interval
   /// Example:
   /// ```dart
   /// Interval.P5.distanceBetween(Note.c, Note.d)
-  ///   == (2, notes: const [Note.c, Note.g, Note.d])
+  ///   == const (2, notes: [Note.c, Note.g, Note.d])
   /// Interval.P5.distanceBetween(Note.a, Note.g)
-  ///   == (-2, notes: const [Note.a, Note.d, Note.g])
+  ///   == const (-2, notes: [Note.a, Note.d, Note.g])
   /// (-Interval.P5).distanceBetween(Note.b.flat, Note.d)
   ///   == (-4, notes: [Note.b.flat, Note.f, Note.d, Note.g, Note.d])
   /// Interval.P4.distanceBetween(Note.f, Note.a.flat)

--- a/lib/src/interval/interval_class.dart
+++ b/lib/src/interval/interval_class.dart
@@ -15,7 +15,7 @@ import 'size.dart';
 /// The shortest distance in pitch class space between two unordered
 /// [PitchClass]es.
 ///
-/// The largest [IntervalClass] is [IntervalClass.tritone] (6) since any greater
+/// The largest [IntervalClass] is the [tritone] (6 semitones) since any greater
 /// interval `n` may be reduced to `chromaticDivisions - n`.
 ///
 /// See [Interval class](https://en.wikipedia.org/wiki/Interval_class).

--- a/lib/src/note/note.dart
+++ b/lib/src/note/note.dart
@@ -13,7 +13,6 @@ import '../scalable.dart';
 import 'accidental.dart';
 import 'base_note.dart';
 import 'pitch.dart';
-import 'pitch_class.dart';
 
 /// A musical note.
 ///
@@ -407,16 +406,6 @@ final class Note extends Scalable<Note> implements Comparable<Note> {
       Accidental(semitonesOctaveMod * interval.size.sign),
     );
   }
-
-  /// Creates a new [PitchClass] from [semitones].
-  ///
-  /// Example:
-  /// ```dart
-  /// Note.c.toPitchClass() == PitchClass.c
-  /// Note.e.sharp.toPitchClass() == PitchClass.f
-  /// Note.c.flat.flat.toPitchClass() == PitchClass.aSharp
-  /// ```
-  PitchClass toPitchClass() => PitchClass(semitones);
 
   /// The string representation of this [Note] based on [system].
   ///

--- a/lib/src/scalable.dart
+++ b/lib/src/scalable.dart
@@ -1,4 +1,4 @@
-import 'class_mixin.dart';
+import 'enharmonic.dart';
 import 'interval/interval.dart';
 import 'music.dart';
 import 'note/pitch_class.dart';
@@ -6,7 +6,7 @@ import 'transposable.dart';
 
 /// A interface for items that can form scales.
 abstract class Scalable<T extends Scalable<T>>
-    with ClassMixin<PitchClass>
+    with Enharmonic<PitchClass>
     implements Transposable<T> {
   /// Creates a new [Scalable].
   const Scalable();

--- a/lib/src/scale/scale.dart
+++ b/lib/src/scale/scale.dart
@@ -2,7 +2,7 @@ import 'package:collection/collection.dart'
     show ListEquality, UnmodifiableListView;
 import 'package:meta/meta.dart' show immutable;
 
-import '../class_mixin.dart';
+import '../enharmonic.dart';
 import '../harmony/chord.dart';
 import '../harmony/harmonic_function.dart';
 import '../interval/interval.dart';

--- a/lib/src/scale/scale_pattern.dart
+++ b/lib/src/scale/scale_pattern.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart' show UnmodifiableListView;
 import 'package:meta/meta.dart' show immutable;
 
-import '../class_mixin.dart';
+import '../enharmonic.dart';
 import '../harmony/chord_pattern.dart';
 import '../interval/interval.dart';
 import '../music.dart';

--- a/test/src/note/note_test.dart
+++ b/test/src/note/note_test.dart
@@ -648,13 +648,13 @@ void main() {
       });
     });
 
-    group('.toPitchClass()', () {
+    group('.toClass()', () {
       test('creates a new PitchClass from semitones', () {
-        expect(Note.c.toPitchClass(), PitchClass.c);
-        expect(Note.d.sharp.toPitchClass(), PitchClass.dSharp);
-        expect(Note.e.flat.toPitchClass(), PitchClass.dSharp);
-        expect(Note.e.sharp.toPitchClass(), PitchClass.f);
-        expect(Note.c.flat.flat.toPitchClass(), PitchClass.aSharp);
+        expect(Note.c.toClass(), PitchClass.c);
+        expect(Note.d.sharp.toClass(), PitchClass.dSharp);
+        expect(Note.e.flat.toClass(), PitchClass.dSharp);
+        expect(Note.e.sharp.toClass(), PitchClass.f);
+        expect(Note.c.flat.flat.toClass(), PitchClass.aSharp);
       });
     });
 


### PR DESCRIPTION
This is the second attempt to revive the `Enharmonic` entity (see #194 and #250).

The difference between the older approach (#250) is that instead of being a superclass of both `PitchClass` and `IntervalClass`, it is designed as a mixin for `Note`, `Pitch`, and `Interval` classes to tell which _enharmonic_ entity they're related to.