### PR TITLE
refactor(interval): 📖 remove ignored `prefer_const_constructors` lint

### DIFF
--- a/lib/src/interval/interval.dart
+++ b/lib/src/interval/interval.dart
@@ -439,8 +439,6 @@ final class Interval
   /// -Interval.perfect(-Size.fifth) == Interval.P5
   /// -Interval.m3 == (-Size.third).minor
   /// ```
-  // See https://github.com/dart-lang/sdk/issues/55728
-  // ignore: prefer_const_constructors
   Interval operator -() => Interval._(-size, quality);
 
   @override


### PR DESCRIPTION
After https://github.com/dart-lang/linter/issues/4978 is fixed