### PR TITLE
fix(size): 🐛 use correct `isPerfect` assert condition in constructor

### DIFF
--- a/lib/src/interval/size.dart
+++ b/lib/src/interval/size.dart
@@ -306,7 +306,7 @@ extension type const PerfectSize._(int size) implements Size {
   const PerfectSize(this.size)
       // Copied from [Size.isPerfect] to allow const.
       : assert(
-          ((size < 0 ? -size : size) + (size < 0 ? -size : size) ~/ 8) % 4 < 2,
+          ((1 << ((size < 0 ? 0 - size : size) % 7)) & 50) != 0,
           'Interval must be perfect.',
         );
 
@@ -343,7 +343,7 @@ extension type const ImperfectSize._(int size) implements Size {
   const ImperfectSize(this.size)
       // Copied from [Size.isPerfect] to allow const.
       : assert(
-          ((size < 0 ? -size : size) + (size < 0 ? -size : size) ~/ 8) % 4 >= 2,
+          ((1 << ((size < 0 ? 0 - size : size) % 7)) & 50) == 0,
           'Interval must be imperfect.',
         );
 

--- a/lib/src/interval/size.dart
+++ b/lib/src/interval/size.dart
@@ -306,7 +306,7 @@ extension type const PerfectSize._(int size) implements Size {
   const PerfectSize(this.size)
       // Copied from [Size.isPerfect] to allow const.
       : assert(
-          ((1 << ((size < 0 ? 0 - size : size) % 7)) & 50) != 0,
+          ((1 << ((size < 0 ? -size : size) % 7)) & 50) != 0,
           'Interval must be perfect.',
         );
 
@@ -343,7 +343,7 @@ extension type const ImperfectSize._(int size) implements Size {
   const ImperfectSize(this.size)
       // Copied from [Size.isPerfect] to allow const.
       : assert(
-          ((1 << ((size < 0 ? 0 - size : size) % 7)) & 50) == 0,
+          ((1 << ((size < 0 ? -size : size) % 7)) & 50) == 0,
           'Interval must be imperfect.',
         );
 

--- a/test/src/interval/size_test.dart
+++ b/test/src/interval/size_test.dart
@@ -4,7 +4,19 @@ import 'package:test/test.dart';
 void main() {
   group('Size', () {
     group('constructor', () {
-      test('creates a different Size.unison ascending and descending', () {
+      test('asserts the size argument is correct', () {
+        expect(const Size(3), Size.third);
+        expect(const Size(-10), -Size.tenth);
+        expect(const PerfectSize(11), Size.eleventh);
+        expect(const ImperfectSize(14), const Size(14));
+
+        expect(() => PerfectSize(16), throwsA(isA<AssertionError>()));
+        expect(() => PerfectSize(51), throwsA(isA<AssertionError>()));
+        expect(() => ImperfectSize(22), throwsA(isA<AssertionError>()));
+        expect(() => ImperfectSize(47), throwsA(isA<AssertionError>()));
+      });
+
+      test('creates different ascending and descending Size.unison', () {
         expect(Size.unison, isNot(-Size.unison));
       });
     });


### PR DESCRIPTION
Continues #544, fixes #545.