### PR TITLE
refactor(note): ♻️ rewrite `transposeBy` method without `absShift`

### DIFF
--- a/.github/workflows/analysis-ci.yaml
+++ b/.github/workflows/analysis-ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: dart pub get
 
       - name: Analyze project source
-        run: dart analyze
+        run: dart analyze --fatal-infos
 
       - name: Run tests
         run: |

--- a/lib/src/interval/size.dart
+++ b/lib/src/interval/size.dart
@@ -135,14 +135,6 @@ extension type const Size._(int size) implements int {
     return (_sizeToSemitones[absSimple]! + octaves * 12) * sign;
   }
 
-  /// The absolute [Size] value taking octave shift into account.
-  @Deprecated('This getter is not reliable on large Intervals')
-  int get absShift {
-    final absSize = abs();
-
-    return absSize + absSize ~/ octave;
-  }
-
   /// The [PerfectQuality.diminished] or [ImperfectQuality.diminished] interval
   /// from this [Size].
   ///

--- a/lib/src/note/note.dart
+++ b/lib/src/note/note.dart
@@ -4,7 +4,6 @@ import 'package:music_notes/utils.dart';
 import '../harmony/chord.dart';
 import '../harmony/chord_pattern.dart';
 import '../interval/interval.dart';
-import '../interval/size.dart';
 import '../key/key.dart';
 import '../key/key_signature.dart';
 import '../key/mode.dart';
@@ -407,7 +406,7 @@ final class Note extends Scalable<Note>
     final accidentalSemitones = (accidental.semitones * interval.size.sign) +
         ((interval.semitones * interval.size.sign) - positiveDifference);
     final semitonesOctaveMod = accidentalSemitones -
-        chromaticDivisions * (interval.size.absShift ~/ Size.octave);
+        chromaticDivisions * ((interval.size.abs() - 1) ~/ 7);
 
     return Note(
       transposedBaseNote,

--- a/test/src/note/note_test.dart
+++ b/test/src/note/note_test.dart
@@ -645,6 +645,17 @@ void main() {
         expect(Note.c.transposeBy(const Interval.perfect(Size(15))), Note.c);
         expect(Note.c.transposeBy(const Interval.perfect(Size(22))), Note.c);
         expect(Note.c.transposeBy(const Interval.perfect(Size(29))), Note.c);
+        expect(Note.c.transposeBy(const ImperfectSize(30).minor), Note.d.flat);
+        expect(Note.c.transposeBy(const ImperfectSize(30).major), Note.d);
+        expect(Note.c.transposeBy(const Interval.perfect(Size(32))), Note.f);
+        expect(
+          Note.c.transposeBy(const PerfectSize(32).augmented),
+          Note.f.sharp,
+        );
+        expect(
+          Note.c.transposeBy(const PerfectSize(33).diminished),
+          Note.g.flat,
+        );
       });
     });
 


### PR DESCRIPTION
Fixes #545.