### PR TITLE
feat(scale_pattern): ✨ add Lydian augmented `name`

### DIFF
--- a/lib/src/scale/scale_pattern.dart
+++ b/lib/src/scale/scale_pattern.dart
@@ -474,6 +474,7 @@ final class ScalePattern {
     dorian => 'Dorian',
     phrygian => 'Phrygian',
     lydian => 'Lydian',
+    lydianAugmented => 'Lydian augmented',
     mixolydian => 'Mixolydian',
     aeolian => 'Natural minor (aeolian)',
     locrian => 'Locrian',

--- a/test/src/scale/scale_pattern_test.dart
+++ b/test/src/scale/scale_pattern_test.dart
@@ -599,6 +599,7 @@ void main() {
         expect(ScalePattern.dorian.name, 'Dorian');
         expect(ScalePattern.phrygian.name, 'Phrygian');
         expect(ScalePattern.lydian.name, 'Lydian');
+        expect(ScalePattern.lydianAugmented.name, 'Lydian augmented');
         expect(ScalePattern.mixolydian.name, 'Mixolydian');
         expect(ScalePattern.aeolian.name, 'Natural minor (aeolian)');
         expect(ScalePattern.locrian.name, 'Locrian');


### PR DESCRIPTION
Add lydianAugmented with getting the name of the default scale patterns