### PR TITLE
refactor(interval): ♻️ use `sizeNotation` RegExp pattern to match the `Interval.size`

### DIFF
--- a/lib/src/interval/interval.dart
+++ b/lib/src/interval/interval.dart
@@ -555,14 +555,16 @@ final class IntervalNotation extends NotationSystem<Interval> {
     return '$naming ($quality${sizeNotation.format(interval.simple.size)})';
   }
 
-  static final _regExp = RegExp(r'(?<quality>\w+?)(?<size>-?\d+)');
-
   @override
-  RegExp get regExp => _regExp;
+  RegExp get regExp =>
+      // TODO(albertms10): use `qualityNotation.regExp.pattern` when duplicated
+      //  named capture groups are supported.
+      //  See https://github.com/dart-lang/sdk/issues/61337.
+      RegExp('(?<quality>\\w+?)\\s*${sizeNotation.regExp.pattern}');
 
   @override
   Interval parseMatch(RegExpMatch match) {
-    final size = sizeNotation.parse(match.namedGroup('size')!);
+    final size = sizeNotation.parseMatch(match);
     // ignore: omit_local_variable_types False positive (?)
     final Parser<Quality> parser = size.isPerfect
         ? perfectQualityNotation
@@ -573,6 +575,6 @@ final class IntervalNotation extends NotationSystem<Interval> {
       throw FormatException('Invalid Quality', quality, 0);
     }
 
-    return Interval._(size, parser.parse(quality));
+    return Interval._(size, parser.parseMatch(match));
   }
 }

--- a/test/src/interval/interval_test.dart
+++ b/test/src/interval/interval_test.dart
@@ -297,6 +297,7 @@ void main() {
         expect(() => Interval.parse('M+6'), throwsFormatException);
         expect(() => Interval.parse('P--6'), throwsFormatException);
         expect(() => Interval.parse('P6'), throwsFormatException);
+        expect(() => Interval.parse('P- 2'), throwsFormatException);
         expect(() => Interval.parse('m4'), throwsFormatException);
         expect(() => Interval.parse('p5'), throwsFormatException);
         expect(() => Interval.parse('a2'), throwsFormatException);
@@ -313,6 +314,7 @@ void main() {
         expect(Interval.parse('P1'), Interval.P1);
         expect(Interval.parse('P22'), const Interval.perfect(Size(22)));
         expect(Interval.parse('d5'), Interval.d5);
+        expect(Interval.parse('d 5'), Interval.d5);
         expect(Interval.parse('d-5'), -Interval.d5);
         expect(
           Interval.parse('dd8'),
@@ -335,7 +337,7 @@ void main() {
         expect(Interval.parse('M-3'), -Interval.M3);
         expect(Interval.parse('M16'), const ImperfectSize(16).major);
         expect(Interval.parse('m2'), Interval.m2);
-        expect(Interval.parse('m-2'), -Interval.m2);
+        expect(Interval.parse('m -2'), -Interval.m2);
         expect(Interval.parse('d7'), Interval.d7);
         expect(
           Interval.parse('dd9'),


### PR DESCRIPTION
Pending to use `qualityNotation` RegExp pattern as well when duplicated named capture groups are supported. See https://github.com/dart-lang/sdk/issues/61337.