### PR TITLE
fix(key): ⌨️ use standard capitalized `TonalMode` in `GermanKeyNotation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Represent it using any notation formatter:
 ```dart
 Note.d.flat.major.toString(); // D♭ major
 Note.c.major.toString(formatter: const RomanceKeyNotation()); // Do maggiore
-Note.e.flat.minor.toString(formatter: const GermanKeyNotation()); // es-moll
+Note.e.flat.minor.toString(formatter: const GermanKeyNotation()); // es-Moll
 ```
 
 ### Key signatures

--- a/example/main.dart
+++ b/example/main.dart
@@ -185,7 +185,7 @@ void main() {
 
   Note.d.flat.major.toString(); // D♭ major
   Note.c.major.toString(formatter: const RomanceKeyNotation()); // Do maggiore
-  Note.e.flat.minor.toString(formatter: const GermanKeyNotation()); // es-moll
+  Note.e.flat.minor.toString(formatter: const GermanKeyNotation()); // es-Moll
 
   // Key signatures
   KeySignature.fromDistance(4); // {E major, C♯ minor} +4 fifths (F♯ C♯ G♯ D♯)

--- a/lib/src/key/key.dart
+++ b/lib/src/key/key.dart
@@ -118,8 +118,8 @@ final class Key implements Comparable<Key> {
   /// Note.f.sharp.minor.toString(formatter: romance) == 'Fa♯ minore'
   ///
   /// const german = GermanKeyNotation();
-  /// Note.e.flat.major.toString(formatter: german) == 'Es-dur'
-  /// Note.g.sharp.minor.toString(formatter: german) == 'gis-moll'
+  /// Note.e.flat.major.toString(formatter: german) == 'Es-Dur'
+  /// Note.g.sharp.minor.toString(formatter: german) == 'gis-Moll'
   /// ```
   @override
   String toString({
@@ -202,7 +202,7 @@ final class GermanKeyNotation extends StringNotationSystem<Key> {
   @override
   String format(Key key) {
     final note = noteNotation.format(key.note);
-    final mode = tonalModeNotation.format(key.mode).toLowerCase();
+    final mode = tonalModeNotation.format(key.mode);
     final casedNote = switch (key.mode) {
       .major => note,
       .minor => note.toLowerCase(),

--- a/test/src/key/key_test.dart
+++ b/test/src/key/key_test.dart
@@ -183,18 +183,18 @@ void main() {
       });
 
       test('parses source as a Key', () {
-        expect(Key.parse('C-dur', chain: chain), Note.c.major);
+        expect(Key.parse('C-Dur', chain: chain), Note.c.major);
         expect(Key.parse('B-dur', chain: chain), Note.b.flat.major);
         expect(Key.parse('b-dur', chain: chain), Note.b.flat.major);
-        expect(Key.parse('H-moll', chain: chain), Note.b.minor);
+        expect(Key.parse('H-Moll', chain: chain), Note.b.minor);
         expect(Key.parse('D-dur', chain: chain), Note.d.major);
         expect(
           Key.parse('Gisis-dur', chain: chain),
           Note.g.sharp.sharp.major,
         );
-        expect(Key.parse('a-moll', chain: chain), Note.a.minor);
-        expect(Key.parse('as-moll', chain: chain), Note.a.flat.minor);
-        expect(Key.parse('d-moll', chain: chain), Note.d.minor);
+        expect(Key.parse('a-Moll', chain: chain), Note.a.minor);
+        expect(Key.parse('As-moll', chain: chain), Note.a.flat.minor);
+        expect(Key.parse('d-Moll', chain: chain), Note.d.minor);
       });
 
       test('.toString() and .parse() are inverses', () {
@@ -216,17 +216,17 @@ void main() {
 
     group('.toString()', () {
       test('returns the string representation of this Key', () {
-        expect(Note.c.major.toString(formatter: formatter), 'C-dur');
-        expect(Note.d.minor.toString(formatter: formatter), 'd-moll');
-        expect(Note.a.flat.major.toString(formatter: formatter), 'As-dur');
-        expect(Note.f.sharp.minor.toString(formatter: formatter), 'fis-moll');
+        expect(Note.c.major.toString(formatter: formatter), 'C-Dur');
+        expect(Note.d.minor.toString(formatter: formatter), 'd-Moll');
+        expect(Note.a.flat.major.toString(formatter: formatter), 'As-Dur');
+        expect(Note.f.sharp.minor.toString(formatter: formatter), 'fis-Moll');
         expect(
           Note.g.sharp.sharp.major.toString(formatter: formatter),
-          'Gisis-dur',
+          'Gisis-Dur',
         );
         expect(
           Note.e.flat.flat.minor.toString(formatter: formatter),
-          'eses-moll',
+          'eses-Moll',
         );
       });
     });


### PR DESCRIPTION
See [G. Henle Blog: A-Dur oder A-dur? Große Fragen um ein kleines „d“](https://blog.henle.de/de/2012/04/10/a-dur/)

Reverts #421