### PR TITLE
feat(key): ✨ support shorter `EnglishKeyNotation` and `RomanceKeyNotation`

### DIFF
--- a/lib/src/key/english_key_notation.dart
+++ b/lib/src/key/english_key_notation.dart
@@ -1,3 +1,5 @@
+import 'package:music_notes/utils.dart';
+
 import '../mode/mode.dart';
 import '../notation_system/notation_system.dart';
 import '../note/english_note_notation.dart';
@@ -11,29 +13,61 @@ final class EnglishKeyNotation extends StringNotationSystem<Key> {
   /// The [EnglishTonalModeNotation] used to format the [Key.mode].
   final EnglishTonalModeNotation tonalModeNotation;
 
+  /// Whether to show the [Key.mode] in the formatted string.
+  final bool _showMode;
+
   /// Creates a new [EnglishKeyNotation].
   const EnglishKeyNotation({
     this.noteNotation = const EnglishNoteNotation(),
     this.tonalModeNotation = const EnglishTonalModeNotation(),
-  });
+  }) : _showMode = true;
 
   /// Creates a new symbolic [EnglishKeyNotation].
   const EnglishKeyNotation.symbol({
     this.noteNotation = const EnglishNoteNotation.symbol(),
     this.tonalModeNotation = const EnglishTonalModeNotation(),
-  });
+  }) : _showMode = true;
+
+  /// Creates a new symbolic [EnglishKeyNotation] using ASCII characters.
+  const EnglishKeyNotation.ascii({
+    this.noteNotation = const EnglishNoteNotation.ascii(),
+    this.tonalModeNotation = const EnglishTonalModeNotation(),
+  }) : _showMode = false;
+
+  /// Creates a new symbolic [EnglishKeyNotation] without showing the mode.
+  const EnglishKeyNotation.short({
+    this.noteNotation = const EnglishNoteNotation.symbol(),
+    this.tonalModeNotation = const EnglishTonalModeNotation(),
+  }) : _showMode = false;
 
   @override
   RegExp get regExp => RegExp(
-    '${noteNotation.regExp.pattern}\\s+${tonalModeNotation.regExp.pattern}',
+    '${noteNotation.regExp.pattern}(?:\\s+${tonalModeNotation.regExp.pattern})'
+    '${_showMode ? '' : '?'}',
     caseSensitive: false,
   );
 
   @override
-  Key parseMatch(RegExpMatch match) =>
-      Key(noteNotation.parseMatch(match), tonalModeNotation.parseMatch(match));
+  Key parseMatch(RegExpMatch match) {
+    final note = noteNotation.parseMatch(match);
+    if (match.namedGroup('mode') != null) {
+      return Key(note, tonalModeNotation.parseMatch(match));
+    }
+
+    return Key(
+      note,
+      match.namedGroup('noteName')![0].isUpperCase ? .major : .minor,
+    );
+  }
 
   @override
-  String format(Key key) =>
-      '${noteNotation.format(key.note)} ${tonalModeNotation.format(key.mode)}';
+  String format(Key key) {
+    final note = noteNotation.format(key.note);
+    if (_showMode) return '$note ${tonalModeNotation.format(key.mode)}';
+
+    return switch (key.mode) {
+      .major => note,
+      .minor => note.toLowerCase(),
+    };
+  }
 }

--- a/lib/src/key/german_key_notation.dart
+++ b/lib/src/key/german_key_notation.dart
@@ -30,7 +30,8 @@ final class GermanKeyNotation extends StringNotationSystem<Key> {
 
   @override
   RegExp get regExp => RegExp(
-    '${noteNotation.regExp.pattern}(:?-${tonalModeNotation.regExp.pattern})?',
+    '${noteNotation.regExp.pattern}(:?-${tonalModeNotation.regExp.pattern})'
+    '${_showMode ? '' : '?'}',
     caseSensitive: false,
   );
 

--- a/lib/src/key/key.dart
+++ b/lib/src/key/key.dart
@@ -35,9 +35,14 @@ final class Key implements Comparable<Key>, Formattable<Key> {
   static const parsers = [
     EnglishKeyNotation(),
     EnglishKeyNotation.symbol(),
+    EnglishKeyNotation.ascii(),
+    EnglishKeyNotation.short(),
     GermanKeyNotation(),
+    GermanKeyNotation.short(),
     RomanceKeyNotation(),
     RomanceKeyNotation.symbol(),
+    RomanceKeyNotation.ascii(),
+    RomanceKeyNotation.short(),
   ];
 
   /// Parse [source] as a [Key] and return its value.

--- a/lib/src/key/romance_key_notation.dart
+++ b/lib/src/key/romance_key_notation.dart
@@ -1,3 +1,5 @@
+import 'package:music_notes/utils.dart';
+
 import '../mode/mode.dart';
 import '../notation_system/notation_system.dart';
 import '../note/romance_note_notation.dart';
@@ -11,29 +13,61 @@ final class RomanceKeyNotation extends StringNotationSystem<Key> {
   /// The [RomanceTonalModeNotation] used to format the [Key.mode].
   final RomanceTonalModeNotation tonalModeNotation;
 
+  /// Whether to show the [Key.mode] in the formatted string.
+  final bool _showMode;
+
   /// Creates a new [RomanceKeyNotation].
   const RomanceKeyNotation({
     this.noteNotation = const RomanceNoteNotation(),
     this.tonalModeNotation = const RomanceTonalModeNotation(),
-  });
+  }) : _showMode = true;
 
   /// Creates a new symbolic [RomanceKeyNotation].
   const RomanceKeyNotation.symbol({
     this.noteNotation = const RomanceNoteNotation.symbol(),
     this.tonalModeNotation = const RomanceTonalModeNotation(),
-  });
+  }) : _showMode = true;
+
+  /// Creates a new symbolic [RomanceKeyNotation] using ASCII characters.
+  const RomanceKeyNotation.ascii({
+    this.noteNotation = const RomanceNoteNotation.ascii(),
+    this.tonalModeNotation = const RomanceTonalModeNotation(),
+  }) : _showMode = true;
+
+  /// Creates a new symbolic [RomanceKeyNotation] without showing the mode.
+  const RomanceKeyNotation.short({
+    this.noteNotation = const RomanceNoteNotation.symbol(),
+    this.tonalModeNotation = const RomanceTonalModeNotation(),
+  }) : _showMode = false;
 
   @override
   RegExp get regExp => RegExp(
-    '${noteNotation.regExp.pattern}\\s+${tonalModeNotation.regExp.pattern}',
+    '${noteNotation.regExp.pattern}(?:\\s+${tonalModeNotation.regExp.pattern})'
+    '${_showMode ? '' : '?'}',
     caseSensitive: false,
   );
 
   @override
-  Key parseMatch(RegExpMatch match) =>
-      Key(noteNotation.parseMatch(match), tonalModeNotation.parseMatch(match));
+  Key parseMatch(RegExpMatch match) {
+    final note = noteNotation.parseMatch(match);
+    if (match.namedGroup('mode') != null) {
+      return Key(note, tonalModeNotation.parseMatch(match));
+    }
+
+    return Key(
+      note,
+      match.namedGroup('noteName')![0].isUpperCase ? .major : .minor,
+    );
+  }
 
   @override
-  String format(Key key) =>
-      '${noteNotation.format(key.note)} ${tonalModeNotation.format(key.mode)}';
+  String format(Key key) {
+    final note = noteNotation.format(key.note);
+    if (_showMode) return '$note ${tonalModeNotation.format(key.mode)}';
+
+    return switch (key.mode) {
+      .major => note,
+      .minor => note.toLowerCase(),
+    };
+  }
 }

--- a/test/src/key_test.dart
+++ b/test/src/key_test.dart
@@ -139,12 +139,17 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
   });
 
   group('EnglishKeyNotation', () {
-    const formatter = EnglishKeyNotation();
-    const chain = [formatter];
+    const textual = EnglishKeyNotation();
+    const symbol = EnglishKeyNotation.symbol();
+    const short = EnglishKeyNotation.short();
+    const chain = [textual, symbol, short];
 
     group('.parse()', () {
       test('throws a FormatException when source is invalid', () {
-        expect(() => Key.parse('C', chain: chain), throwsFormatException);
+        expect(
+          () => Key.parse('C', chain: const [textual]),
+          throwsFormatException,
+        );
         expect(() => Key.parse('major', chain: chain), throwsFormatException);
         expect(
           () => Key.parse('C major minor', chain: chain),
@@ -154,12 +159,18 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
       });
 
       test('parses source as a Key', () {
+        expect(Key.parse('A'), Note.a.major);
+        expect(Key.parse('d'), Note.d.minor);
+        expect(Key.parse('f#'), Note.f.sharp.minor);
+        expect(Key.parse('bb'), Note.b.flat.minor);
         expect(Key.parse('C major'), Note.c.major);
         expect(Key.parse('D major'), Note.d.major);
-        expect(Key.parse('F♯ major'), Note.f.sharp.major);
+        expect(Key.parse('f♯ major'), Note.f.sharp.major);
         expect(Key.parse('A minor'), Note.a.minor);
-        expect(Key.parse('D minor'), Note.d.minor);
+        expect(Key.parse('G-flat major'), Note.g.flat.major);
+        expect(Key.parse('d minor'), Note.d.minor);
         expect(Key.parse('C♯ minor'), Note.c.sharp.minor);
+        expect(Key.parse('C-double-sharp minor'), Note.c.sharp.sharp.minor);
       });
 
       test('.format() and .parse() are inverses', () {
@@ -184,6 +195,23 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
         expect(Note.f.sharp.minor.format(), 'F♯ minor');
         expect(Note.g.sharp.sharp.major.format(), 'G𝄪 major');
         expect(Note.e.flat.flat.minor.format(), 'E𝄫 minor');
+
+        expect(Note.c.major.format(textual), 'C major');
+        expect(Note.d.minor.format(textual), 'D minor');
+        expect(Note.a.flat.major.format(textual), 'A-flat major');
+        expect(Note.f.sharp.minor.format(textual), 'F-sharp minor');
+        expect(
+          Note.g.sharp.sharp.major.format(textual),
+          'G-double-sharp major',
+        );
+        expect(Note.e.flat.flat.minor.format(textual), 'E-double-flat minor');
+
+        expect(Note.c.major.format(short), 'C');
+        expect(Note.d.minor.format(short), 'd');
+        expect(Note.a.flat.major.format(short), 'A♭');
+        expect(Note.f.sharp.minor.format(short), 'f♯');
+        expect(Note.g.sharp.sharp.major.format(short), 'G𝄪');
+        expect(Note.e.flat.flat.minor.format(short), 'e𝄫');
       });
     });
   });
@@ -195,6 +223,10 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
 
     group('.parse()', () {
       test('throws a FormatException when source is invalid', () {
+        expect(
+          () => Key.parse('C', chain: const [formatter]),
+          throwsFormatException,
+        );
         expect(() => Key.parse('dur', chain: chain), throwsFormatException);
         expect(
           () => Key.parse('C-dur-moll', chain: chain),
@@ -264,11 +296,15 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
   group('RomanceKeyNotation', () {
     const textual = RomanceKeyNotation();
     const symbol = RomanceKeyNotation.symbol();
-    const chain = [textual, symbol];
+    const short = RomanceKeyNotation.short();
+    const chain = [textual, symbol, short];
 
     group('.parse()', () {
       test('throws a FormatException when source is invalid', () {
-        expect(() => Key.parse('Do', chain: chain), throwsFormatException);
+        expect(
+          () => Key.parse('Do', chain: const [textual]),
+          throwsFormatException,
+        );
         expect(
           () => Key.parse('maggiore', chain: chain),
           throwsFormatException,
@@ -281,6 +317,7 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
       });
 
       test('parses source as a Key', () {
+        expect(Key.parse('Do', chain: chain), Note.c.major);
         expect(Key.parse('Do maggiore', chain: chain), Note.c.major);
         expect(Key.parse('Sol# maggiore', chain: chain), Note.g.sharp.major);
         expect(
@@ -288,13 +325,18 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
           Note.f.sharp.minor,
         );
         expect(Key.parse('Re maggiore', chain: chain), Note.d.major);
-        expect(Key.parse('Lab minore', chain: chain), Note.a.flat.minor);
+        expect(Key.parse('La♭ minore', chain: chain), Note.a.flat.minor);
         expect(
           Key.parse('La bemolle minore', chain: chain),
           Note.a.flat.minor,
         );
         expect(Key.parse('La minore', chain: chain), Note.a.minor);
         expect(Key.parse('Re minore', chain: chain), Note.d.minor);
+
+        expect(Key.parse('Re', chain: chain), Note.d.major);
+        expect(Key.parse('do', chain: chain), Note.c.minor);
+        expect(Key.parse('la#', chain: chain), Note.a.sharp.minor);
+        expect(Key.parse('Mib', chain: chain), Note.e.flat.major);
       });
 
       test('.format() and .parse() are inverses', () {
@@ -336,6 +378,11 @@ Key(note: Note(noteName: NoteName.g, accidental: Accidental(semitones: 1)), mode
           Note.e.flat.flat.minor.format(symbol),
           'Mi𝄫 minore',
         );
+
+        expect(Note.c.major.format(short), 'Do');
+        expect(Note.b.minor.format(short), 'si');
+        expect(Note.a.sharp.major.format(short), 'La♯');
+        expect(Note.e.flat.minor.format(short), 'mi♭');
       });
     });
   });


### PR DESCRIPTION
Continues #732