### PR TITLE
fix(rational): 🐛 make equality exact and hash-consistent

### DIFF
--- a/lib/src/utils/rational.dart
+++ b/lib/src/utils/rational.dart
@@ -98,14 +98,20 @@ final class Rational implements Comparable<Rational> {
     return Rational(numerator, bestDenominator);
   }
 
-  /// The simplified version of this [Rational].
-  Rational get simple {
+  (int, int) get _canonical {
     final divisor = _numerator.gcd(_denominator);
 
-    return Rational(
+    return (
       _denominator.nonZeroSign * (_numerator ~/ divisor),
       _denominator.abs() ~/ divisor,
     );
+  }
+
+  /// The simplified version of this [Rational].
+  Rational get simple {
+    final (numerator, denominator) = _canonical;
+
+    return Rational(numerator, denominator);
   }
 
   /// Truncates this [Rational] to an integer and returns the result as an
@@ -181,13 +187,19 @@ final class Rational implements Comparable<Rational> {
   /// ```
   Rational operator -() => Rational(-_numerator, _denominator);
 
+  /// Two [Rational]s are equal iff they represent the same exact rational
+  /// number.
   @override
   bool operator ==(Object other) =>
-      (other is num && other == toDouble()) ||
-      (other is Rational && other.toDouble() == toDouble());
+      other is Rational &&
+      _numerator * other._denominator == other._numerator * _denominator;
 
   @override
-  int get hashCode => toDouble().hashCode;
+  int get hashCode {
+    final (numerator, denominator) = _canonical;
+
+    return Object.hash(numerator, denominator);
+  }
 
   @override
   int compareTo(Rational other) {

--- a/test/utils/rational_test.dart
+++ b/test/utils/rational_test.dart
@@ -221,4 +221,99 @@ void main() {
       });
     });
   });
+
+  group('operator ==()', () {
+    test('equal rationals compare equal', () {
+      expect(const Rational(1, 2), equals(const Rational(1, 2)));
+    });
+
+    test('equivalent fractions compare equal', () {
+      expect(const Rational(1, 2), equals(const Rational(2, 4)));
+      expect(const Rational(-1, 2), equals(const Rational(-2, 4)));
+    });
+
+    test('different rationals do not compare equal', () {
+      expect(const Rational(1, 2), isNot(equals(const Rational(2, 3))));
+    });
+
+    test('equality is independent of denominator sign', () {
+      expect(const Rational(1, 2), equals(const Rational(-1, -2)));
+      expect(const Rational(-1, 2), equals(const Rational(1, -2)));
+    });
+
+    test('equality is symmetric', () {
+      const a = Rational(1, 2);
+      const b = Rational(2, 4);
+
+      expect(a == b, isTrue);
+      expect(b == a, isTrue);
+    });
+
+    test('reflexive', () {
+      const rational = Rational(3, 4);
+
+      expect(rational == rational, isTrue);
+    });
+
+    test('symmetric', () {
+      const a = Rational(1, 2);
+      const b = Rational(2, 4);
+
+      expect(a == b, equals(b == a));
+    });
+
+    test('transitive', () {
+      const a = Rational(1, 2);
+      const b = Rational(2, 4);
+      const c = Rational(50, 100);
+
+      expect(a == b, isTrue);
+      expect(b == c, isTrue);
+      expect(a == c, isTrue);
+    });
+
+    test('equal values behave correctly in a Set', () {
+      final values = {
+        const Rational(1, 2),
+        const Rational(2, 4),
+        const Rational(50, 100),
+      };
+
+      expect(values, hasLength(1));
+    });
+
+    test('equal values behave correctly as Map keys', () {
+      final map = <Rational, String>{const Rational(1, 2): 'half'};
+
+      expect(map[const Rational(2, 4)], equals('half'));
+    });
+  });
+
+  group('.hashCode', () {
+    test('equal rationals have equal hash codes', () {
+      expect(
+        const Rational(1, 2).hashCode,
+        equals(const Rational(2, 4).hashCode),
+      );
+    });
+
+    test(
+      'equal rationals have equal hash codes with negative denominators',
+      () {
+        expect(
+          const Rational(1, 2).hashCode,
+          equals(const Rational(-1, -2).hashCode),
+        );
+      },
+    );
+
+    test('hashCode is consistent across equivalent representations', () {
+      const a = Rational(1, 2);
+      const b = Rational(2, 4);
+      const c = Rational(50, 100);
+
+      expect(a.hashCode, equals(b.hashCode));
+      expect(b.hashCode, equals(c.hashCode));
+    });
+  });
 }


### PR DESCRIPTION
Use exact rational equality instead of double conversion and derive `hashCode` from the canonical representation, ensuring that equal `Rational`s always have equal hash codes.